### PR TITLE
Make Scryfall errors easier to catch and handle

### DIFF
--- a/examples/handle_errors.py
+++ b/examples/handle_errors.py
@@ -1,0 +1,8 @@
+import scrython
+
+# oops, we asked for an exact match to a card, but failed to put the name in quotes
+# that's going to throw a Scryfall error
+try:
+    search = scrython.cards.Search(q="!Black Lotus")
+except scrython.ScryfallError as e:
+    print(str(e.status) + ' ' + e.code + ': ' + e.details)

--- a/examples/handle_errors.py
+++ b/examples/handle_errors.py
@@ -5,4 +5,4 @@ import scrython
 try:
     search = scrython.cards.Search(q="!Black Lotus")
 except scrython.ScryfallError as e:
-    print(str(e.status) + ' ' + e.code + ': ' + e.details)
+    print(str(e.error_details['status']) + ' ' + e.error_details['code'] + ': ' + e.error_details['details'])

--- a/scrython/__init__.py
+++ b/scrython/__init__.py
@@ -41,6 +41,9 @@ from scrython.symbology import Symbology
 #Import bulk-data
 from scrython.bulk_data import BulkData
 
+#Utility
+from scrython.foundation import ScryfallError
+
 __all__ = [
     'Autocomplete',
     'Collector',
@@ -72,5 +75,6 @@ __all__ = [
     'ArtistNames',
     'ParseMana',
     'Symbology',
-    'BulkData'
+    'BulkData',
+    'ScryfallError',
 ]

--- a/scrython/foundation.py
+++ b/scrython/foundation.py
@@ -35,7 +35,7 @@ class FoundationObject(object):
         loop.run_until_complete(main(loop))
 
         if self.scryfallJson['object'] == 'error':
-            raise ScryfallError(self.scryfallJson, message=self.scryfallJson['details'])
+            raise ScryfallError(self.scryfallJson, self.scryfallJson['details'])
 
     def _checkForKey(self, key):
         """Checks for a key in the scryfallJson object.

--- a/scrython/foundation.py
+++ b/scrython/foundation.py
@@ -5,7 +5,8 @@ import urllib
 class ScryfallError(Exception):
     def __init__(self, error_obj, *args, **kwargs):
         super(self.__class__, self).__init__(*args, **kwargs)
-        self.error_details = **error_obj
+        self.error_details = {}
+        self.error_details.update(error_obj)
 
 
 class FoundationObject(object):

--- a/scrython/foundation.py
+++ b/scrython/foundation.py
@@ -2,6 +2,12 @@ import aiohttp
 import asyncio
 import urllib
 
+class ScryfallError(Exception):
+    def __init__(self, error_obj, *args, **kwargs):
+        super(self.__class__, self).__init__(*args, **kwargs)
+        self.error_details = **error_obj
+
+
 class FoundationObject(object):
 
     def __init__(self, _url, override=False, **kwargs):
@@ -28,7 +34,7 @@ class FoundationObject(object):
         loop.run_until_complete(main(loop))
 
         if self.scryfallJson['object'] == 'error':
-            raise Exception(self.scryfallJson['details'])
+            raise ScryfallError(self.scryfallJson, message=self.scryfallJson['details'])
 
     def _checkForKey(self, key):
         """Checks for a key in the scryfallJson object.


### PR DESCRIPTION
This change would make Scryfall errors catchable and easier to handle. For one, it adds a unique exception type. And it also copies over the [Error object](https://scryfall.com/docs/api/errors) details, allowing a machine to handle things like the different 404s.