### PR TITLE
Adding adventure to list of card layouts for image_uris

### DIFF
--- a/scrython/cards/cards_object.py
+++ b/scrython/cards/cards_object.py
@@ -164,7 +164,8 @@ class CardsObject(FoundationObject):
             'double_faced_token': lambda num: self.scryfallJson['card_faces'][num]['image_uris'],
             'emblem': lambda num: self.scryfallJson['image_uris'],
             'augment': lambda num: self.scryfallJson['image_uris'],
-            'host': lambda num: self.scryfallJson['image_uris']
+            'host': lambda num: self.scryfallJson['image_uris'],
+            'adventure': lambda num: self.scryfallJson['image_uris']
         }
 
         image_types = {


### PR DESCRIPTION
Currently Scrython breaks when trying to call the image uris of cards with the new Adventure frame. Took a quick look, and it seems to be an easy fix. Let me know if there's anything else I need to do here.