### PR TITLE
add support to class cards

### DIFF
--- a/scrython/cards/cards_object.py
+++ b/scrython/cards/cards_object.py
@@ -167,6 +167,7 @@ class CardsObject(FoundationObject):
             'meld': lambda num: self.scryfallJson['image_uris'],
             'leveler': lambda num: self.scryfallJson['image_uris'],
             'saga': lambda num: self.scryfallJson['image_uris'],
+            'class': lambda num: self.scryfallJson['image_uris'],
             'planar': lambda num: self.scryfallJson['image_uris'],
             'scheme': lambda num: self.scryfallJson['image_uris'],
             'vanguard': lambda num: self.scryfallJson['image_uris'],


### PR DESCRIPTION
With the new expansion "forgotten realms", they added a new type of cards: class cards. This is one example

[cleric class json response](https://api.scryfall.com/cards/47ce8b7e-d8e1-489a-a69e-99089eeb8739?format=json&pretty=true) and [cleric class scryfall view](https://scryfall.com/card/afr/6/cleric-class). 

So basically I added a one-liner to support them. Can you please merge the PR?

Thanks! 😄