### PR TITLE
Bugfix/download encoding mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Scrython
+# Scrython
 
 Scrython is a wrapper for the Scryfall API, designed for an easier use.
 
@@ -238,6 +238,8 @@ cards = oracle_cards.download(progress=True)
 # - 'all_cards': All card printings
 # - 'rulings': All card rulings
 ```
+
+**Note:** The `download()` method automatically detects whether responses are gzip-compressed by checking HTTP `Content-Encoding` headers. This means it works seamlessly regardless of Scryfall's CDN configuration - you don't need to worry about compression formats.
 
 ### Error Handling
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scrython"
-version = "2.0.0"
+version = "2.0.1"
 description = "A wrapper for using the Scryfall API."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This PR fixes an issue where the content type for a `bulk_data` download was assumed to be a `gzip` even if a CDN provider might not be compressing it. The fix is to check the response `Content-Encoding` headers instead of assuming that it's always gzipped.