### PR TITLE
Update `tqdm` import for Jupyter compatibility.

### DIFF
--- a/scrython/bulk_data/bulk_data_mixins.py
+++ b/scrython/bulk_data/bulk_data_mixins.py
@@ -164,7 +164,7 @@ class BulkDataObjectMixin:
         # Optional progress bar
         if progress:
             try:
-                from tqdm import tqdm
+                from tqdm.auto import tqdm
             except ImportError as exc:
                 raise ImportError(
                     "tqdm is required for progress bars. "


### PR DESCRIPTION
This PR just updates the `tqdm` import to use `tqdm.auto` to help Jupyter import the correct version for visual compatability. Very simple.