### PR TITLE
feat: add per-endpoint rate limiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dmypy.json
 
 # Python version
 .python-version
+docs
+scripts

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,4 @@ dmypy.json
 
 # Python version
 .python-version
-docs
-scripts
+docs/superpowers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.0.1] - Unreleased
+
+### Added
+- **Per-endpoint rate limiting**: Scryfall enforces tiered rate limits. `Search`, `Named`, `Random`, and `Collection` endpoints now automatically enforce 2 requests/second; all other endpoints enforce 10 requests/second. See [Scryfall rate limit docs](https://scryfall.com/docs/api/rate-limits).
+- **`SlowRateLimiter` subclass**: New rate limiter class for endpoints with stricter limits. Endpoint classes declare their tier via `_rate_limiter_class` class variable.
+- **Per-class limiter registry**: Each `RateLimiter` subclass maintains its own global instance, allowing independent rate limits per endpoint category.
+
+### Changed
+- `rate_limit_per_second` kwarg now creates a per-instance limiter scoped to the handler's lifecycle. Separate instantiations do not coordinate with each other; pagination within a single handler (`iter_all()`) is properly throttled.
+- `reset_global_limiter()` renamed to `reset_all_limiters()`. The old name still works but emits a `DeprecationWarning`.
+- `get_global_limiter()` no longer accepts a `calls_per_second` argument. Passing one emits a `DeprecationWarning` and the value is ignored. Rate is determined by the class default.
+- Passing `rate_limit_per_second` to `iter_all()` now emits a `UserWarning` and is ignored. The kwarg must be set at construction time.
+
+---
+
 ## [2.0.0] - 2025-01-11 (Rewrite Branch)
 
 Major refactoring and modernization of the Scrython library with significant improvements to code quality, type safety, and usability.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2.0.1] - Unreleased
+## [2.0.3] - Unreleased
 
 ### Added
 - **Per-endpoint rate limiting**: Scryfall enforces tiered rate limits. `Search`, `Named`, `Random`, and `Collection` endpoints now automatically enforce 2 requests/second; all other endpoints enforce 10 requests/second. See [Scryfall rate limit docs](https://scryfall.com/docs/api/rate-limits).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ The library uses a **base request handler** (`ScrythonRequestHandler`) combined 
 scrython/
 ├── base.py              # ScrythonRequestHandler, ScryfallError
 ├── base_mixins.py       # ScryfallListMixin, ScryfallCatalogMixin
+├── rate_limiter.py      # RateLimiter, SlowRateLimiter (per-endpoint tiering)
+├── cache.py             # Request caching with TTL
 ├── utils.py             # Utility functions (e.g., to_object_array)
 ├── cards/
 │   ├── cards.py         # Card endpoint classes + Cards factory
@@ -91,11 +93,11 @@ From Contributing.md:
 
 ## Important Notes
 
-- **No rate limiting**: Library doesn't enforce Scryfall's rate limits - users must handle this themselves (e.g., `time.sleep(0.1)`)
+- **Built-in rate limiting**: Automatic per-endpoint rate limiting (10/s default, 2/s for search/named/random/collection). See `scrython/rate_limiter.py`. Users can override with `rate_limit_per_second` kwarg or disable with `rate_limit=False`.
 - **No backwards compatibility**: Breaking changes expected as Scryfall API evolves
-- **Walrus operator usage**: Code uses `:=` (requires Python 3.8+)
-- **Dependencies**: python >= 3.5.3, asyncio >= 3.4.3, aiohttp >= 3.4.4 (though current code uses urllib, not aiohttp)
-- **Branches**: `master` is stable/PyPI, `develop` is staging (per Contributing.md, though current branch is `rewrite`)
+- **Python 3.10+ required**: Uses `X | Y` union syntax and `type[X]` annotations throughout
+- **Dependencies**: urllib (standard library), no external HTTP dependencies
+- **Branches**: `main` is stable/PyPI, `develop` is staging
 
 ## Adding New Endpoints
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ pip install scrython
 
 ## ⚠️ Important: Rate Limiting
 
-**Good news!** Scrython 2.0 now includes **built-in rate limiting** enabled by default, enforcing Scryfall's 10 requests/second guideline automatically. You no longer need to manually add delays between requests.
+**Good news!** Scrython 2.0 includes **built-in rate limiting** enabled by default. You no longer need to manually add delays between requests.
 
-**Scryfall requires 50-100 milliseconds delay between requests** (~10 requests/second maximum).
+Scrython automatically enforces Scryfall's tiered rate limits:
+- **10 requests/second** for most endpoints (cards by ID, sets, bulk data, autocomplete, etc.)
+- **2 requests/second** for heavier endpoints: `Search`, `Named`, `Random`, and `Collection`
+
+See [Scryfall's rate limit documentation](https://scryfall.com/docs/api/rate-limits) for details.
 
 ### Automatic Rate Limiting (Default):
 
@@ -27,17 +31,17 @@ import scrython
 cards_to_fetch = ['Lightning Bolt', 'Counterspell', 'Black Lotus']
 
 for card_name in cards_to_fetch:
-    card = scrython.cards.Named(fuzzy=card_name)  # Automatically rate limited
+    card = scrython.cards.Named(fuzzy=card_name)  # Automatically rate limited (2/s)
     print(f"{card.name} - {card.set}")
 ```
 
 ### Custom Rate Limits:
 
 ```python
-# Use a slower rate (5 requests/second)
+# Override the rate for a specific call (5 requests/second)
 card = scrython.cards.Named(fuzzy='Lightning Bolt', rate_limit_per_second=5)
 
-# Disable rate limiting (use with caution!)
+# Disable rate limiting entirely (use with caution!)
 card = scrython.cards.Named(fuzzy='Lightning Bolt', rate_limit=False)
 ```
 
@@ -53,7 +57,7 @@ import time
 for card_name in cards_to_fetch:
     card = scrython.cards.Named(fuzzy=card_name, rate_limit=False)
     print(f"{card.name} - {card.set}")
-    time.sleep(0.1)  # 100ms delay
+    time.sleep(0.5)  # 500ms delay for Named endpoint
 ```
 
 ### Better: Use Bulk Data for Large Datasets

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ for card_name in cards_to_fetch:
 
 ```python
 # Override the rate for a specific call (5 requests/second)
+# Note: the override is scoped to this handler instance only.
+# Separate instantiations each get their own limiter.
 card = scrython.cards.Named(fuzzy='Lightning Bolt', rate_limit_per_second=5)
 
 # Disable rate limiting entirely (use with caution!)

--- a/gen_docs.py
+++ b/gen_docs.py
@@ -68,7 +68,6 @@ def format_functions(_class, function_list, f):
 
 def main(subpackage):
     for _class in subpackage.__all__:
-
         intro = f"""
 These docs will likely not be as detailed as the official Scryfall Documentation, and you should reference that for more information.
 

--- a/scripts/update_version_for_testpypi.py
+++ b/scripts/update_version_for_testpypi.py
@@ -20,6 +20,7 @@ def get_unique_identifier() -> str:
 
     # Fallback for local testing: use timestamp
     from datetime import datetime, timezone
+
     return datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
 
 
@@ -51,7 +52,7 @@ def update_version_in_pyproject() -> str:
         f'version = "{new_version}"',
         content,
         count=1,
-        flags=re.MULTILINE
+        flags=re.MULTILINE,
     )
 
     # Write back (temporary, only in workflow workspace)

--- a/scrython/base.py
+++ b/scrython/base.py
@@ -167,6 +167,11 @@ class ScrythonRequestHandler:
 
         if rate_limit:
             rate_limit_per_second = kwargs.get("rate_limit_per_second")
+            # Note: kwarg overrides use a separate registry key (cls, rate) from the
+            # class default (cls). If a caller alternates between providing and omitting
+            # rate_limit_per_second, the two limiters operate independently and will
+            # not respect each other's timing. This is an acceptable trade-off —
+            # mixing override and default usage on the same endpoint is uncommon.
 
             if rate_limit_per_second is not None:
                 limiter = self._rate_limiter_class.get_global_limiter_for_rate(

--- a/scrython/base.py
+++ b/scrython/base.py
@@ -59,6 +59,7 @@ class ScrythonRequestHandler:
     _content_type: str = "application/json"
     _endpoint: str = ""
     _rate_limiter_class: type[RateLimiter] = RateLimiter
+    _override_limiter: RateLimiter | None = None
 
     @classmethod
     def set_user_agent(cls, user_agent: str) -> None:

--- a/scrython/base.py
+++ b/scrython/base.py
@@ -167,11 +167,11 @@ class ScrythonRequestHandler:
 
         if rate_limit:
             rate_limit_per_second = kwargs.get("rate_limit_per_second")
-            # Note: kwarg overrides use a separate registry key (cls, rate) from the
-            # class default (cls). If a caller alternates between providing and omitting
-            # rate_limit_per_second, the two limiters operate independently and will
-            # not respect each other's timing. This is an acceptable trade-off —
-            # mixing override and default usage on the same endpoint is uncommon.
+            # Note: kwarg overrides use a flat registry key ("override", rate),
+            # separate from the class default key (cls). If a caller alternates
+            # between providing and omitting rate_limit_per_second, the two
+            # limiters operate independently. All overrides at the same rate
+            # share a single limiter regardless of endpoint class.
 
             if rate_limit_per_second is not None:
                 limiter = self._rate_limiter_class.get_global_limiter_for_rate(

--- a/scrython/base.py
+++ b/scrython/base.py
@@ -166,7 +166,7 @@ class ScrythonRequestHandler:
         rate_limit = kwargs.get("rate_limit", True)
 
         if rate_limit:
-            rate_limit_per_second = kwargs.get("rate_limit_per_second", None)
+            rate_limit_per_second = kwargs.get("rate_limit_per_second")
 
             if rate_limit_per_second is not None:
                 limiter = RateLimiter(rate_limit_per_second)

--- a/scrython/base.py
+++ b/scrython/base.py
@@ -58,6 +58,7 @@ class ScrythonRequestHandler:
     _accept: str = "application/json"
     _content_type: str = "application/json"
     _endpoint: str = ""
+    _rate_limiter_class: type[RateLimiter] = RateLimiter
 
     @classmethod
     def set_user_agent(cls, user_agent: str) -> None:
@@ -139,7 +140,7 @@ class ScrythonRequestHandler:
                 - cache (bool): Enable caching (default: False)
                 - cache_ttl (int): Cache TTL in seconds (default: 3600)
                 - rate_limit (bool): Enable rate limiting (default: True)
-                - rate_limit_per_second (float): Rate limit (default: 10.0)
+                - rate_limit_per_second (float): Rate limit override (default: uses endpoint's limiter class)
                 - data (dict): POST data (optional)
 
         Returns:
@@ -165,13 +166,13 @@ class ScrythonRequestHandler:
         rate_limit = kwargs.get("rate_limit", True)
 
         if rate_limit:
-            # Get rate limit setting
-            rate_limit_per_second = kwargs.get("rate_limit_per_second", 10.0)
+            rate_limit_per_second = kwargs.get("rate_limit_per_second", None)
 
-            # Get or create global rate limiter
-            limiter = RateLimiter.get_global_limiter(rate_limit_per_second)
+            if rate_limit_per_second is not None:
+                limiter = RateLimiter(rate_limit_per_second)
+            else:
+                limiter = self._rate_limiter_class.get_global_limiter()
 
-            # Wait if necessary to respect rate limit
             limiter.wait()
 
         # Prepare POST data if provided

--- a/scrython/base.py
+++ b/scrython/base.py
@@ -118,6 +118,11 @@ class ScrythonRequestHandler:
         return self._endpoint
 
     def __init__(self, **kwargs: Any) -> None:
+        rate_limit_per_second = kwargs.get("rate_limit_per_second")
+        self._override_limiter: RateLimiter | None = None
+        if rate_limit_per_second is not None:
+            self._override_limiter = RateLimiter(rate_limit_per_second)
+
         self._build_path(**kwargs)
         self._build_params(**kwargs)
         self._fetch(**kwargs)
@@ -140,7 +145,6 @@ class ScrythonRequestHandler:
                 - cache (bool): Enable caching (default: False)
                 - cache_ttl (int): Cache TTL in seconds (default: 3600)
                 - rate_limit (bool): Enable rate limiting (default: True)
-                - rate_limit_per_second (float): Rate limit override (default: uses endpoint's limiter class)
                 - data (dict): POST data (optional)
 
         Returns:
@@ -166,17 +170,10 @@ class ScrythonRequestHandler:
         rate_limit = kwargs.get("rate_limit", True)
 
         if rate_limit:
-            rate_limit_per_second = kwargs.get("rate_limit_per_second")
-            # Note: kwarg overrides use a flat registry key ("override", rate),
-            # separate from the class default key (cls). If a caller alternates
-            # between providing and omitting rate_limit_per_second, the two
-            # limiters operate independently. All overrides at the same rate
-            # share a single limiter regardless of endpoint class.
-
-            if rate_limit_per_second is not None:
-                limiter = self._rate_limiter_class.get_global_limiter_for_rate(
-                    rate_limit_per_second
-                )
+            # Use the instance override limiter if set, otherwise fall back
+            # to the class-level global limiter for the endpoint's tier.
+            if self._override_limiter is not None:
+                limiter = self._override_limiter
             else:
                 limiter = self._rate_limiter_class.get_global_limiter()
 

--- a/scrython/base.py
+++ b/scrython/base.py
@@ -169,7 +169,9 @@ class ScrythonRequestHandler:
             rate_limit_per_second = kwargs.get("rate_limit_per_second")
 
             if rate_limit_per_second is not None:
-                limiter = RateLimiter(rate_limit_per_second)
+                limiter = self._rate_limiter_class.get_global_limiter_for_rate(
+                    rate_limit_per_second
+                )
             else:
                 limiter = self._rate_limiter_class.get_global_limiter()
 

--- a/scrython/base.py
+++ b/scrython/base.py
@@ -118,6 +118,20 @@ class ScrythonRequestHandler:
         return self._endpoint
 
     def __init__(self, **kwargs: Any) -> None:
+        """
+        Initialize a Scryfall API request handler.
+
+        Args:
+            **kwargs: Endpoint-specific parameters, plus optional:
+                - rate_limit (bool): Enable rate limiting (default: True)
+                - rate_limit_per_second (float): Override the default rate limit
+                    for this handler instance. Creates a per-instance limiter,
+                    so separate instantiations do not coordinate with each other
+                    or with the class default limiter. Pagination within a single
+                    handler (e.g., iter_all()) is properly throttled.
+                - cache (bool): Enable caching (default: False)
+                - cache_ttl (int): Cache TTL in seconds (default: 3600)
+        """
         rate_limit_per_second = kwargs.get("rate_limit_per_second")
         self._override_limiter: RateLimiter | None = None
         if rate_limit_per_second is not None:

--- a/scrython/base_mixins.py
+++ b/scrython/base_mixins.py
@@ -1,3 +1,4 @@
+import warnings
 from functools import cache
 from typing import Any
 
@@ -106,6 +107,10 @@ class ScryfallListMixin:
                 - cache_ttl (int): Cache TTL in seconds (default: 3600)
                 - rate_limit (bool): Enable rate limiting (default: True)
 
+        Note:
+            rate_limit_per_second must be set at construction time, not here.
+            Pagination uses the handler's existing rate limiter.
+
         Yields:
             Individual items from all pages
 
@@ -119,6 +124,15 @@ class ScryfallListMixin:
                 print(card.name)
         """
         import hashlib
+
+        if "rate_limit_per_second" in kwargs:
+            warnings.warn(
+                "rate_limit_per_second must be set at construction time, "
+                "not passed to iter_all(). This kwarg is ignored.",
+                UserWarning,
+                stacklevel=2,
+            )
+            kwargs.pop("rate_limit_per_second")
 
         # Yield items from current page
         yield from self.data

--- a/scrython/base_mixins.py
+++ b/scrython/base_mixins.py
@@ -105,7 +105,6 @@ class ScryfallListMixin:
                 - cache (bool): Enable caching for pagination (default: False)
                 - cache_ttl (int): Cache TTL in seconds (default: 3600)
                 - rate_limit (bool): Enable rate limiting (default: True)
-                - rate_limit_per_second (float): Rate limit (default: 10.0)
 
         Yields:
             Individual items from all pages

--- a/scrython/cards/cards.py
+++ b/scrython/cards/cards.py
@@ -1,5 +1,6 @@
 from ..base import ScrythonRequestHandler
 from ..base_mixins import ScryfallCatalogMixin, ScryfallListMixin
+from ..rate_limiter import SlowRateLimiter
 from ..types import ScryfallCardData
 from .cards_mixins import CardsObjectMixin
 
@@ -158,6 +159,7 @@ class Search(ScryfallListMixin, ScrythonRequestHandler):
     """
 
     _endpoint = "/cards/search"
+    _rate_limiter_class = SlowRateLimiter
     list_data_type = Object
 
 
@@ -189,6 +191,7 @@ class Named(CardsObjectMixin, ScrythonRequestHandler):
     """
 
     _endpoint = "/cards/named"
+    _rate_limiter_class = SlowRateLimiter
 
 
 class Autocomplete(ScryfallCatalogMixin, ScrythonRequestHandler):
@@ -244,6 +247,7 @@ class Random(CardsObjectMixin, ScrythonRequestHandler):
     """
 
     _endpoint = "/cards/random"
+    _rate_limiter_class = SlowRateLimiter
 
 
 class Collection(ScryfallListMixin, ScrythonRequestHandler):
@@ -276,6 +280,7 @@ class Collection(ScryfallListMixin, ScrythonRequestHandler):
     """
 
     _endpoint = "/cards/collection"
+    _rate_limiter_class = SlowRateLimiter
     list_data_type = Object
 
 

--- a/scrython/rate_limiter.py
+++ b/scrython/rate_limiter.py
@@ -26,7 +26,7 @@ class RateLimiter:
     """
 
     # Per-class registry of global rate limiter instances
-    _global_limiters: ClassVar[dict[type | tuple[str, float], "RateLimiter"]] = {}
+    _global_limiters: ClassVar[dict[type, "RateLimiter"]] = {}
     _global_lock: ClassVar[threading.Lock] = threading.Lock()
 
     def __init__(self, calls_per_second: float = 10.0) -> None:
@@ -81,28 +81,6 @@ class RateLimiter:
             if cls not in cls._global_limiters:
                 cls._global_limiters[cls] = cls()
             return cls._global_limiters[cls]
-
-    @classmethod
-    def get_global_limiter_for_rate(cls, calls_per_second: float) -> "RateLimiter":
-        """
-        Get or create a shared rate limiter for a specific rate.
-
-        This allows rate_limit_per_second overrides to share state
-        across consecutive calls with the same rate value. Overrides
-        are keyed by rate alone (not by class), so all endpoints
-        overriding to the same rate share a single limiter.
-
-        Args:
-            calls_per_second: The rate to enforce
-
-        Returns:
-            A shared RateLimiter instance for the given rate
-        """
-        key = ("override", calls_per_second)
-        with cls._global_lock:
-            if key not in cls._global_limiters:
-                cls._global_limiters[key] = RateLimiter(calls_per_second)
-            return cls._global_limiters[key]
 
     @classmethod
     def reset_all_limiters(cls) -> None:

--- a/scrython/rate_limiter.py
+++ b/scrython/rate_limiter.py
@@ -70,8 +70,8 @@ class RateLimiter:
         """
         Get or create the global rate limiter for this class.
 
-        Each RateLimiter subclass maintains its own independent global
-        instance, keyed by class in a shared registry. This allows
+        Each RateLimiter class or subclass maintains its own independent
+        global instance, keyed by class in a shared registry. This allows
         different endpoint categories to enforce different rate limits.
 
         Returns:

--- a/scrython/rate_limiter.py
+++ b/scrython/rate_limiter.py
@@ -23,7 +23,7 @@ class RateLimiter:
     """
 
     # Per-class registry of global rate limiter instances
-    _global_limiters: ClassVar[dict[type, "RateLimiter"]] = {}
+    _global_limiters: ClassVar[dict[type | tuple[type, float], "RateLimiter"]] = {}
     _global_lock: ClassVar[threading.Lock] = threading.Lock()
 
     def __init__(self, calls_per_second: float = 10.0) -> None:
@@ -80,7 +80,27 @@ class RateLimiter:
             return cls._global_limiters[cls]
 
     @classmethod
-    def reset_global_limiter(cls) -> None:
+    def get_global_limiter_for_rate(cls, calls_per_second: float) -> "RateLimiter":
+        """
+        Get or create a shared rate limiter for a specific rate.
+
+        This allows rate_limit_per_second overrides to share state
+        across consecutive calls with the same rate value.
+
+        Args:
+            calls_per_second: The rate to enforce
+
+        Returns:
+            A shared RateLimiter instance for the given rate
+        """
+        key = (cls, calls_per_second)
+        with cls._global_lock:
+            if key not in cls._global_limiters:
+                cls._global_limiters[key] = cls(calls_per_second)
+            return cls._global_limiters[key]
+
+    @classmethod
+    def reset_all_limiters(cls) -> None:
         """
         Reset all global rate limiters.
 

--- a/scrython/rate_limiter.py
+++ b/scrython/rate_limiter.py
@@ -1,8 +1,10 @@
 """Rate limiting for Scryfall API requests.
 
-Scryfall requests a rate limit of 10 requests per second. This module
-provides a thread-safe rate limiter that enforces this limit by default,
-while allowing users to opt-out or customize the rate limit.
+Scryfall requests a rate limit of 10 requests per second for most endpoints,
+but enforces a stricter 2 requests per second for certain card endpoints.
+
+This module provides a thread-safe rate limiter with a per-class registry,
+allowing different endpoint categories to maintain independent rate limits.
 """
 
 import threading
@@ -20,8 +22,8 @@ class RateLimiter:
     The limiter is thread-safe and can be shared across multiple threads.
     """
 
-    # Class-level (global) rate limiter shared across all instances
-    _global_limiter: ClassVar["RateLimiter | None"] = None
+    # Per-class registry of global rate limiter instances
+    _global_limiters: ClassVar[dict[type, "RateLimiter"]] = {}
     _global_lock: ClassVar[threading.Lock] = threading.Lock()
 
     def __init__(self, calls_per_second: float = 10.0) -> None:
@@ -61,32 +63,43 @@ class RateLimiter:
             self.last_call = time.time()
 
     @classmethod
-    def get_global_limiter(cls, calls_per_second: float = 10.0) -> "RateLimiter":
+    def get_global_limiter(cls) -> "RateLimiter":
         """
-        Get or create the global rate limiter instance.
+        Get or create the global rate limiter for this class.
 
-        This ensures that all API requests share a single rate limiter,
-        preventing rate limit violations even when multiple objects are
-        created concurrently.
-
-        Args:
-            calls_per_second: Rate limit to use if creating a new limiter
+        Each RateLimiter subclass maintains its own independent global
+        instance, keyed by class in a shared registry. This allows
+        different endpoint categories to enforce different rate limits.
 
         Returns:
-            The global RateLimiter instance
+            The global RateLimiter instance for this class
         """
         with cls._global_lock:
-            if cls._global_limiter is None:
-                cls._global_limiter = cls(calls_per_second)
-            return cls._global_limiter
+            if cls not in cls._global_limiters:
+                cls._global_limiters[cls] = cls()
+            return cls._global_limiters[cls]
 
     @classmethod
     def reset_global_limiter(cls) -> None:
         """
-        Reset the global rate limiter.
+        Reset all global rate limiters.
 
-        This is primarily useful for testing to ensure a clean state
-        between test runs.
+        Clears the entire registry, causing new instances to be created
+        on the next call to get_global_limiter(). This is primarily
+        useful for testing to ensure a clean state between test runs.
         """
         with cls._global_lock:
-            cls._global_limiter = None
+            cls._global_limiters.clear()
+
+
+class SlowRateLimiter(RateLimiter):
+    """
+    Rate limiter for Scryfall endpoints with stricter rate limits.
+
+    Scryfall enforces 2 requests per second on certain card endpoints
+    (search, named, random, collection). This subclass
+    provides that slower default rate.
+    """
+
+    def __init__(self, calls_per_second: float = 2.0) -> None:
+        super().__init__(calls_per_second)

--- a/scrython/rate_limiter.py
+++ b/scrython/rate_limiter.py
@@ -26,7 +26,7 @@ class RateLimiter:
     """
 
     # Per-class registry of global rate limiter instances
-    _global_limiters: ClassVar[dict[type | tuple[type, float], "RateLimiter"]] = {}
+    _global_limiters: ClassVar[dict[type | tuple[str, float], "RateLimiter"]] = {}
     _global_lock: ClassVar[threading.Lock] = threading.Lock()
 
     def __init__(self, calls_per_second: float = 10.0) -> None:
@@ -88,7 +88,9 @@ class RateLimiter:
         Get or create a shared rate limiter for a specific rate.
 
         This allows rate_limit_per_second overrides to share state
-        across consecutive calls with the same rate value.
+        across consecutive calls with the same rate value. Overrides
+        are keyed by rate alone (not by class), so all endpoints
+        overriding to the same rate share a single limiter.
 
         Args:
             calls_per_second: The rate to enforce
@@ -96,10 +98,10 @@ class RateLimiter:
         Returns:
             A shared RateLimiter instance for the given rate
         """
-        key = (cls, calls_per_second)
+        key = ("override", calls_per_second)
         with cls._global_lock:
             if key not in cls._global_limiters:
-                cls._global_limiters[key] = cls(calls_per_second)
+                cls._global_limiters[key] = RateLimiter(calls_per_second)
             return cls._global_limiters[key]
 
     @classmethod

--- a/scrython/rate_limiter.py
+++ b/scrython/rate_limiter.py
@@ -66,7 +66,7 @@ class RateLimiter:
             self.last_call = time.time()
 
     @classmethod
-    def get_global_limiter(cls) -> "RateLimiter":
+    def get_global_limiter(cls, calls_per_second: float | None = None) -> "RateLimiter":
         """
         Get or create the global rate limiter for this class.
 
@@ -74,9 +74,20 @@ class RateLimiter:
         global instance, keyed by class in a shared registry. This allows
         different endpoint categories to enforce different rate limits.
 
+        Args:
+            calls_per_second: Deprecated, ignored. Rate is determined by
+                the class default. Passing a value emits a DeprecationWarning.
+
         Returns:
             The global RateLimiter instance for this class
         """
+        if calls_per_second is not None:
+            warnings.warn(
+                "calls_per_second argument to get_global_limiter() is deprecated "
+                "and ignored. Rate is determined by the class default.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         with cls._global_lock:
             if cls not in cls._global_limiters:
                 cls._global_limiters[cls] = cls()

--- a/scrython/rate_limiter.py
+++ b/scrython/rate_limiter.py
@@ -11,6 +11,7 @@ allowing different endpoint categories to maintain independent rate limits.
 
 import threading
 import time
+import warnings
 from typing import ClassVar
 
 
@@ -112,6 +113,16 @@ class RateLimiter:
         """
         with cls._global_lock:
             cls._global_limiters.clear()
+
+    @classmethod
+    def reset_global_limiter(cls) -> None:
+        """Deprecated: use reset_all_limiters() instead."""
+        warnings.warn(
+            "reset_global_limiter() is deprecated, use reset_all_limiters() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        cls.reset_all_limiters()
 
 
 class SlowRateLimiter(RateLimiter):

--- a/scrython/rate_limiter.py
+++ b/scrython/rate_limiter.py
@@ -1,7 +1,9 @@
 """Rate limiting for Scryfall API requests.
 
 Scryfall requests a rate limit of 10 requests per second for most endpoints,
-but enforces a stricter 2 requests per second for certain card endpoints.
+but enforces a stricter limit on certain card endpoints.
+
+See: https://scryfall.com/docs/api/rate-limits
 
 This module provides a thread-safe rate limiter with a per-class registry,
 allowing different endpoint categories to maintain independent rate limits.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,10 +20,10 @@ def reset_globals():
 
     Resets rate limiter and cache to ensure tests don't interfere with each other.
     """
-    RateLimiter.reset_global_limiter()
+    RateLimiter.reset_all_limiters()
     reset_global_cache()
     yield
-    RateLimiter.reset_global_limiter()
+    RateLimiter.reset_all_limiters()
     reset_global_cache()
 
 

--- a/tests/test_property_types.py
+++ b/tests/test_property_types.py
@@ -120,10 +120,9 @@ class TestCardCoreFields:
             return
 
         # Otherwise, check the type
-        assert isinstance(value, expected_type), (
-            f"Property '{prop}' ({desc}) returned {type(value).__name__} "
-            f"instead of {expected_type}"
-        )
+        assert isinstance(
+            value, expected_type
+        ), f"Property '{prop}' ({desc}) returned {type(value).__name__} instead of {expected_type}"
 
 
 class TestCardGameplayFields:
@@ -142,10 +141,9 @@ class TestCardGameplayFields:
             return
 
         # Otherwise, check the type
-        assert isinstance(value, expected_type), (
-            f"Property '{prop}' ({desc}) returned {type(value).__name__} "
-            f"instead of {expected_type}"
-        )
+        assert isinstance(
+            value, expected_type
+        ), f"Property '{prop}' ({desc}) returned {type(value).__name__} instead of {expected_type}"
 
 
 class TestCardPrintFields:
@@ -164,10 +162,9 @@ class TestCardPrintFields:
             return
 
         # Otherwise, check the type
-        assert isinstance(value, expected_type), (
-            f"Property '{prop}' ({desc}) returned {type(value).__name__} "
-            f"instead of {expected_type}"
-        )
+        assert isinstance(
+            value, expected_type
+        ), f"Property '{prop}' ({desc}) returned {type(value).__name__} instead of {expected_type}"
 
 
 # Sets Properties Test Data
@@ -212,10 +209,9 @@ class TestSetsObjectFields:
             return
 
         # Otherwise, check the type
-        assert isinstance(value, expected_type), (
-            f"Property '{prop}' ({desc}) returned {type(value).__name__} "
-            f"instead of {expected_type}"
-        )
+        assert isinstance(
+            value, expected_type
+        ), f"Property '{prop}' ({desc}) returned {type(value).__name__} instead of {expected_type}"
 
 
 # Bulk Data Properties Test Data
@@ -250,7 +246,6 @@ class TestBulkDataObjectFields:
             return
 
         # Otherwise, check the type
-        assert isinstance(value, expected_type), (
-            f"Property '{prop}' ({desc}) returned {type(value).__name__} "
-            f"instead of {expected_type}"
-        )
+        assert isinstance(
+            value, expected_type
+        ), f"Property '{prop}' ({desc}) returned {type(value).__name__} instead of {expected_type}"

--- a/tests/test_property_types.py
+++ b/tests/test_property_types.py
@@ -120,9 +120,10 @@ class TestCardCoreFields:
             return
 
         # Otherwise, check the type
-        assert isinstance(
-            value, expected_type
-        ), f"Property '{prop}' ({desc}) returned {type(value).__name__} instead of {expected_type}"
+        assert isinstance(value, expected_type), (
+            f"Property '{prop}' ({desc}) returned {type(value).__name__} "
+            f"instead of {expected_type}"
+        )
 
 
 class TestCardGameplayFields:
@@ -141,9 +142,10 @@ class TestCardGameplayFields:
             return
 
         # Otherwise, check the type
-        assert isinstance(
-            value, expected_type
-        ), f"Property '{prop}' ({desc}) returned {type(value).__name__} instead of {expected_type}"
+        assert isinstance(value, expected_type), (
+            f"Property '{prop}' ({desc}) returned {type(value).__name__} "
+            f"instead of {expected_type}"
+        )
 
 
 class TestCardPrintFields:
@@ -162,9 +164,10 @@ class TestCardPrintFields:
             return
 
         # Otherwise, check the type
-        assert isinstance(
-            value, expected_type
-        ), f"Property '{prop}' ({desc}) returned {type(value).__name__} instead of {expected_type}"
+        assert isinstance(value, expected_type), (
+            f"Property '{prop}' ({desc}) returned {type(value).__name__} "
+            f"instead of {expected_type}"
+        )
 
 
 # Sets Properties Test Data
@@ -209,9 +212,10 @@ class TestSetsObjectFields:
             return
 
         # Otherwise, check the type
-        assert isinstance(
-            value, expected_type
-        ), f"Property '{prop}' ({desc}) returned {type(value).__name__} instead of {expected_type}"
+        assert isinstance(value, expected_type), (
+            f"Property '{prop}' ({desc}) returned {type(value).__name__} "
+            f"instead of {expected_type}"
+        )
 
 
 # Bulk Data Properties Test Data
@@ -246,6 +250,7 @@ class TestBulkDataObjectFields:
             return
 
         # Otherwise, check the type
-        assert isinstance(
-            value, expected_type
-        ), f"Property '{prop}' ({desc}) returned {type(value).__name__} instead of {expected_type}"
+        assert isinstance(value, expected_type), (
+            f"Property '{prop}' ({desc}) returned {type(value).__name__} "
+            f"instead of {expected_type}"
+        )

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -287,7 +287,7 @@ class TestRequestHandlerRateLimiting:
         assert elapsed < 0.3
 
     def test_custom_rate_limit(self, mock_urlopen_with_rate_limit, sample_card):
-        """Test that rate_limit_per_second enforces rate across consecutive calls."""
+        """Test that rate_limit_per_second creates a per-instance limiter."""
         # Reset rate limiter
         RateLimiter.reset_all_limiters()
 
@@ -296,14 +296,15 @@ class TestRequestHandlerRateLimiting:
         class TestHandler(ScrythonRequestHandler):
             _endpoint = "cards/named"
 
-        # Use a slower rate limit (5 calls/sec = 0.2s interval)
+        # Each handler gets its own limiter, so separate instantiations
+        # do not throttle against each other (only pagination within
+        # a single handler instance is throttled).
         start = time.time()
         _handler1 = TestHandler(fuzzy="Card 1", rate_limit_per_second=5.0)
         _handler2 = TestHandler(fuzzy="Card 2", rate_limit_per_second=5.0)
         elapsed = time.time() - start
 
-        # Should wait ~0.2s between calls
-        assert elapsed > 0.18
+        assert elapsed < 0.1
 
     def test_slow_rate_limiter_attributes_via_global(
         self, mock_urlopen_with_rate_limit, sample_card

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -241,7 +241,7 @@ class TestRequestHandlerRateLimiting:
         elapsed = time.time() - start
 
         # Should be very fast (no rate limiting)
-        assert elapsed < 0.15
+        assert elapsed < 0.3
 
     def test_default_rate_limiter_class_is_base(self):
         """Test that ScrythonRequestHandler defaults to RateLimiter."""

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -284,7 +284,7 @@ class TestRequestHandlerRateLimiting:
         elapsed = time.time() - start
 
         # Should be fast (~0.05s), not slow (~0.5s)
-        assert elapsed < 0.15
+        assert elapsed < 0.3
 
     def test_custom_rate_limit(self, mock_urlopen_with_rate_limit, sample_card):
         """Test that rate_limit_per_second enforces rate across consecutive calls."""
@@ -305,8 +305,10 @@ class TestRequestHandlerRateLimiting:
         # Should wait ~0.2s between calls
         assert elapsed > 0.18
 
-    def test_custom_rate_limit_via_subclass(self, mock_urlopen_with_rate_limit, sample_card):
-        """Test that custom rate limits are applied via RateLimiter subclasses."""
+    def test_slow_rate_limiter_attributes_via_global(
+        self, mock_urlopen_with_rate_limit, sample_card
+    ):
+        """Test that SlowRateLimiter global instance has correct default attributes."""
         from scrython.rate_limiter import SlowRateLimiter
 
         # Reset rate limiter
@@ -417,7 +419,7 @@ class TestSlowRateLimiter:
         limiter.wait()
         elapsed = time.time() - start
 
-        assert 0.45 < elapsed < 0.6
+        assert 0.45 < elapsed < 1.0
 
 
 class TestEndpointRateLimiterAssignment:

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -80,7 +80,7 @@ class TestRateLimiter:
     def test_get_global_limiter_creates_singleton(self):
         """Test that get_global_limiter returns a singleton."""
         # Reset first
-        RateLimiter.reset_global_limiter()
+        RateLimiter.reset_all_limiters()
 
         limiter1 = RateLimiter.get_global_limiter()
         limiter2 = RateLimiter.get_global_limiter()
@@ -88,13 +88,13 @@ class TestRateLimiter:
         # Should be the same instance
         assert limiter1 is limiter2
 
-    def test_reset_global_limiter(self):
-        """Test that reset_global_limiter clears the singleton."""
+    def test_reset_all_limiters(self):
+        """Test that reset_all_limiters clears the singleton."""
         # Create a global limiter
         limiter1 = RateLimiter.get_global_limiter()
 
         # Reset
-        RateLimiter.reset_global_limiter()
+        RateLimiter.reset_all_limiters()
 
         # Get another - should be a new instance
         limiter2 = RateLimiter.get_global_limiter()
@@ -112,14 +112,14 @@ class TestRateLimiter:
         assert limiter_fast.calls_per_second == 10.0
         assert limiter_slow.calls_per_second == 2.0
 
-    def test_reset_global_limiter_clears_all(self):
+    def test_reset_all_limiters_clears_all(self):
         """Test that reset clears the entire registry."""
         from scrython.rate_limiter import SlowRateLimiter
 
         old_fast = RateLimiter.get_global_limiter()
         old_slow = SlowRateLimiter.get_global_limiter()
 
-        RateLimiter.reset_global_limiter()
+        RateLimiter.reset_all_limiters()
 
         new_fast = RateLimiter.get_global_limiter()
         new_slow = SlowRateLimiter.get_global_limiter()
@@ -208,7 +208,7 @@ class TestRequestHandlerRateLimiting:
     def test_rate_limit_enabled_by_default(self, mock_urlopen_with_rate_limit, sample_card):
         """Test that rate limiting is enabled by default."""
         # Reset rate limiter
-        RateLimiter.reset_global_limiter()
+        RateLimiter.reset_all_limiters()
 
         mock_urlopen_with_rate_limit.set_response(data=sample_card)
 
@@ -227,7 +227,7 @@ class TestRequestHandlerRateLimiting:
     def test_rate_limit_can_be_disabled(self, mock_urlopen_with_rate_limit, sample_card):
         """Test that rate limiting can be disabled."""
         # Reset rate limiter
-        RateLimiter.reset_global_limiter()
+        RateLimiter.reset_all_limiters()
 
         mock_urlopen_with_rate_limit.set_response(data=sample_card)
 
@@ -287,30 +287,30 @@ class TestRequestHandlerRateLimiting:
         assert elapsed < 0.15
 
     def test_custom_rate_limit(self, mock_urlopen_with_rate_limit, sample_card):
-        """Test that rate_limit_per_second creates a one-off limiter per request."""
+        """Test that rate_limit_per_second enforces rate across consecutive calls."""
         # Reset rate limiter
-        RateLimiter.reset_global_limiter()
+        RateLimiter.reset_all_limiters()
 
         mock_urlopen_with_rate_limit.set_response(data=sample_card)
 
         class TestHandler(ScrythonRequestHandler):
             _endpoint = "cards/named"
 
-        # Each call creates its own limiter, so no shared state between calls
+        # Use a slower rate limit (5 calls/sec = 0.2s interval)
         start = time.time()
         _handler1 = TestHandler(fuzzy="Card 1", rate_limit_per_second=5.0)
         _handler2 = TestHandler(fuzzy="Card 2", rate_limit_per_second=5.0)
         elapsed = time.time() - start
 
-        # One-off limiters have no shared state, so calls are not delayed
-        assert elapsed < 0.1
+        # Should wait ~0.2s between calls
+        assert elapsed > 0.18
 
     def test_custom_rate_limit_via_subclass(self, mock_urlopen_with_rate_limit, sample_card):
         """Test that custom rate limits are applied via RateLimiter subclasses."""
         from scrython.rate_limiter import SlowRateLimiter
 
         # Reset rate limiter
-        RateLimiter.reset_global_limiter()
+        RateLimiter.reset_all_limiters()
 
         mock_urlopen_with_rate_limit.set_response(data=sample_card)
 
@@ -322,7 +322,7 @@ class TestRequestHandlerRateLimiting:
     def test_rate_limit_respects_previous_calls(self, mock_urlopen_with_rate_limit, sample_card):
         """Test that rate limiting considers timing of previous calls."""
         # Reset rate limiter
-        RateLimiter.reset_global_limiter()
+        RateLimiter.reset_all_limiters()
 
         mock_urlopen_with_rate_limit.set_response(data=sample_card)
 
@@ -348,7 +348,7 @@ class TestRequestHandlerRateLimiting:
     ):
         """Test that multiple handlers share the same global rate limiter."""
         # Reset rate limiter
-        RateLimiter.reset_global_limiter()
+        RateLimiter.reset_all_limiters()
 
         mock_urlopen_with_rate_limit.set_response(data=sample_card)
 
@@ -370,7 +370,7 @@ class TestRequestHandlerRateLimiting:
     def test_rate_limit_with_errors_still_enforced(self, mock_urlopen_with_rate_limit):
         """Test that rate limiting is enforced even when API returns errors."""
         # Reset rate limiter
-        RateLimiter.reset_global_limiter()
+        RateLimiter.reset_all_limiters()
 
         mock_urlopen_with_rate_limit.set_error_response(
             {"status": 404, "code": "not_found", "details": "Not found"}

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -101,6 +101,32 @@ class TestRateLimiter:
 
         assert limiter1 is not limiter2
 
+    def test_global_limiter_registry_per_class(self):
+        """Test that different RateLimiter subclasses get independent global instances."""
+        from scrython.rate_limiter import SlowRateLimiter
+
+        limiter_fast = RateLimiter.get_global_limiter()
+        limiter_slow = SlowRateLimiter.get_global_limiter()
+
+        assert limiter_fast is not limiter_slow
+        assert limiter_fast.calls_per_second == 10.0
+        assert limiter_slow.calls_per_second == 2.0
+
+    def test_reset_global_limiter_clears_all(self):
+        """Test that reset clears the entire registry."""
+        from scrython.rate_limiter import SlowRateLimiter
+
+        old_fast = RateLimiter.get_global_limiter()
+        old_slow = SlowRateLimiter.get_global_limiter()
+
+        RateLimiter.reset_global_limiter()
+
+        new_fast = RateLimiter.get_global_limiter()
+        new_slow = SlowRateLimiter.get_global_limiter()
+
+        assert new_fast is not old_fast
+        assert new_slow is not old_slow
+
 
 class TestRequestHandlerRateLimiting:
     """Test rate limiting integration with ScrythonRequestHandler."""
@@ -217,8 +243,49 @@ class TestRequestHandlerRateLimiting:
         # Should be very fast (no rate limiting)
         assert elapsed < 0.05
 
+    def test_default_rate_limiter_class_is_base(self):
+        """Test that ScrythonRequestHandler defaults to RateLimiter."""
+        assert ScrythonRequestHandler._rate_limiter_class is RateLimiter
+
+    def test_slow_endpoint_uses_slow_limiter(self, mock_urlopen_with_rate_limit, sample_card):
+        """Test that an endpoint with SlowRateLimiter uses the slow rate."""
+        from scrython.rate_limiter import SlowRateLimiter
+
+        mock_urlopen_with_rate_limit.set_response(data=sample_card)
+
+        class SlowHandler(ScrythonRequestHandler):
+            _endpoint = "cards/search"
+            _rate_limiter_class = SlowRateLimiter
+
+        start = time.time()
+        _handler1 = SlowHandler(q="Card 1")
+        _handler2 = SlowHandler(q="Card 2")
+        elapsed = time.time() - start
+
+        # SlowRateLimiter at 2/s means ~0.5s between calls
+        assert elapsed > 0.45
+
+    def test_rate_limit_per_second_kwarg_overrides_class(self, mock_urlopen_with_rate_limit, sample_card):
+        """Test that rate_limit_per_second kwarg overrides the class default."""
+        from scrython.rate_limiter import SlowRateLimiter
+
+        mock_urlopen_with_rate_limit.set_response(data=sample_card)
+
+        class SlowHandler(ScrythonRequestHandler):
+            _endpoint = "cards/search"
+            _rate_limiter_class = SlowRateLimiter
+
+        # Override to a fast rate — should NOT wait 500ms
+        start = time.time()
+        _handler1 = SlowHandler(q="Card 1", rate_limit_per_second=20.0)
+        _handler2 = SlowHandler(q="Card 2", rate_limit_per_second=20.0)
+        elapsed = time.time() - start
+
+        # Should be fast (~0.05s), not slow (~0.5s)
+        assert elapsed < 0.15
+
     def test_custom_rate_limit(self, mock_urlopen_with_rate_limit, sample_card):
-        """Test that custom rate limits can be specified."""
+        """Test that rate_limit_per_second creates a one-off limiter per request."""
         # Reset rate limiter
         RateLimiter.reset_global_limiter()
 
@@ -227,14 +294,28 @@ class TestRequestHandlerRateLimiting:
         class TestHandler(ScrythonRequestHandler):
             _endpoint = "cards/named"
 
-        # Use a slower rate limit (5 calls/sec = 0.2s interval)
+        # Each call creates its own limiter, so no shared state between calls
         start = time.time()
         _handler1 = TestHandler(fuzzy="Card 1", rate_limit_per_second=5.0)
         _handler2 = TestHandler(fuzzy="Card 2", rate_limit_per_second=5.0)
         elapsed = time.time() - start
 
-        # Should wait ~0.2s
-        assert elapsed > 0.18
+        # One-off limiters have no shared state, so calls are not delayed
+        assert elapsed < 0.1
+
+    def test_custom_rate_limit_via_subclass(self, mock_urlopen_with_rate_limit, sample_card):
+        """Test that custom rate limits are applied via RateLimiter subclasses."""
+        from scrython.rate_limiter import SlowRateLimiter
+
+        # Reset rate limiter
+        RateLimiter.reset_global_limiter()
+
+        mock_urlopen_with_rate_limit.set_response(data=sample_card)
+
+        limiter = SlowRateLimiter.get_global_limiter()
+
+        assert limiter.calls_per_second == 2.0
+        assert limiter.min_interval == 0.5
 
     def test_rate_limit_respects_previous_calls(self, mock_urlopen_with_rate_limit, sample_card):
         """Test that rate limiting considers timing of previous calls."""
@@ -308,3 +389,70 @@ class TestRequestHandlerRateLimiting:
 
         # Should still be rate limited
         assert elapsed > 0.08
+
+
+class TestSlowRateLimiter:
+    """Test the SlowRateLimiter class."""
+
+    def test_slow_rate_limiter_default_rate(self):
+        """Test that SlowRateLimiter defaults to 2 calls per second."""
+        from scrython.rate_limiter import SlowRateLimiter
+
+        limiter = SlowRateLimiter()
+
+        assert limiter.calls_per_second == 2.0
+        assert limiter.min_interval == 0.5
+
+    def test_slow_rate_limiter_enforces_delay(self):
+        """Test that SlowRateLimiter enforces 500ms delays between calls."""
+        from scrython.rate_limiter import SlowRateLimiter
+
+        limiter = SlowRateLimiter()
+
+        limiter.wait()
+
+        start = time.time()
+        limiter.wait()
+        elapsed = time.time() - start
+
+        assert 0.45 < elapsed < 0.6
+
+
+class TestEndpointRateLimiterAssignment:
+    """Test that endpoint classes declare the correct rate limiter class."""
+
+    def test_search_uses_slow_limiter(self):
+        from scrython.cards.cards import Search
+        from scrython.rate_limiter import SlowRateLimiter
+
+        assert Search._rate_limiter_class is SlowRateLimiter
+
+    def test_named_uses_slow_limiter(self):
+        from scrython.cards.cards import Named
+        from scrython.rate_limiter import SlowRateLimiter
+
+        assert Named._rate_limiter_class is SlowRateLimiter
+
+    def test_random_uses_slow_limiter(self):
+        from scrython.cards.cards import Random
+        from scrython.rate_limiter import SlowRateLimiter
+
+        assert Random._rate_limiter_class is SlowRateLimiter
+
+    def test_collection_uses_slow_limiter(self):
+        from scrython.cards.cards import Collection
+        from scrython.rate_limiter import SlowRateLimiter
+
+        assert Collection._rate_limiter_class is SlowRateLimiter
+
+    def test_autocomplete_uses_default_limiter(self):
+        from scrython.cards.cards import Autocomplete
+        from scrython.rate_limiter import RateLimiter
+
+        assert Autocomplete._rate_limiter_class is RateLimiter
+
+    def test_by_code_number_uses_default_limiter(self):
+        from scrython.cards.cards import ByCodeNumber
+        from scrython.rate_limiter import RateLimiter
+
+        assert ByCodeNumber._rate_limiter_class is RateLimiter

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -35,8 +35,8 @@ class TestRateLimiter:
         limiter.wait()
         first_call_time = time.time() - start
 
-        # Should be very fast (< 0.01s)
-        assert first_call_time < 0.01
+        # Should be very fast
+        assert first_call_time < 0.05
 
         # Second call immediately after should wait
         start = time.time()
@@ -62,7 +62,7 @@ class TestRateLimiter:
         elapsed = time.time() - start
 
         # Should be very fast
-        assert elapsed < 0.01
+        assert elapsed < 0.05
 
     def test_rate_limiter_multiple_calls(self):
         """Test RateLimiter with multiple sequential calls."""
@@ -75,7 +75,7 @@ class TestRateLimiter:
 
         # Should take ~0.2s (4 intervals * 0.05s)
         # First call is immediate, then 4 waits of 0.05s each
-        assert 0.15 < elapsed < 0.3
+        assert 0.15 < elapsed < 0.5
 
     def test_get_global_limiter_creates_singleton(self):
         """Test that get_global_limiter returns a singleton."""
@@ -241,7 +241,7 @@ class TestRequestHandlerRateLimiting:
         elapsed = time.time() - start
 
         # Should be very fast (no rate limiting)
-        assert elapsed < 0.05
+        assert elapsed < 0.15
 
     def test_default_rate_limiter_class_is_base(self):
         """Test that ScrythonRequestHandler defaults to RateLimiter."""
@@ -284,7 +284,7 @@ class TestRequestHandlerRateLimiting:
         elapsed = time.time() - start
 
         # Should be fast (~0.05s), not slow (~0.5s)
-        assert elapsed < 0.3
+        assert elapsed < 0.5
 
     def test_custom_rate_limit(self, mock_urlopen_with_rate_limit, sample_card):
         """Test that rate_limit_per_second creates a per-instance limiter."""
@@ -304,7 +304,7 @@ class TestRequestHandlerRateLimiting:
         _handler2 = TestHandler(fuzzy="Card 2", rate_limit_per_second=5.0)
         elapsed = time.time() - start
 
-        assert elapsed < 0.1
+        assert elapsed < 0.2
 
     def test_slow_rate_limiter_attributes_via_global(
         self, mock_urlopen_with_rate_limit, sample_card
@@ -344,7 +344,7 @@ class TestRequestHandlerRateLimiting:
         elapsed = time.time() - start
 
         # Should wait ~0.05s (remaining time)
-        assert 0.03 < elapsed < 0.08
+        assert 0.03 < elapsed < 0.15
 
     def test_rate_limit_multiple_handlers_share_limiter(
         self, mock_urlopen_with_rate_limit, sample_card

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -265,7 +265,9 @@ class TestRequestHandlerRateLimiting:
         # SlowRateLimiter at 2/s means ~0.5s between calls
         assert elapsed > 0.45
 
-    def test_rate_limit_per_second_kwarg_overrides_class(self, mock_urlopen_with_rate_limit, sample_card):
+    def test_rate_limit_per_second_kwarg_overrides_class(
+        self, mock_urlopen_with_rate_limit, sample_card
+    ):
         """Test that rate_limit_per_second kwarg overrides the class default."""
         from scrython.rate_limiter import SlowRateLimiter
 

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -127,6 +127,16 @@ class TestRateLimiter:
         assert new_fast is not old_fast
         assert new_slow is not old_slow
 
+    def test_get_global_limiter_deprecated_param(self):
+        """Test that passing calls_per_second to get_global_limiter emits a deprecation warning."""
+        RateLimiter.reset_all_limiters()
+
+        with pytest.warns(DeprecationWarning, match="calls_per_second.*deprecated"):
+            limiter = RateLimiter.get_global_limiter(5.0)
+
+        # Should still return the default limiter (argument is ignored)
+        assert limiter.calls_per_second == 10.0
+
 
 class TestRequestHandlerRateLimiting:
     """Test rate limiting integration with ScrythonRequestHandler."""
@@ -305,6 +315,30 @@ class TestRequestHandlerRateLimiting:
         elapsed = time.time() - start
 
         assert elapsed < 0.2
+
+    def test_custom_rate_limit_throttles_within_instance(
+        self, mock_urlopen_with_rate_limit, sample_card
+    ):
+        """Test that rate_limit_per_second throttles repeated calls on the same handler."""
+        RateLimiter.reset_all_limiters()
+
+        mock_urlopen_with_rate_limit.set_response(data=sample_card)
+
+        class TestHandler(ScrythonRequestHandler):
+            _endpoint = "cards/named"
+
+        handler = TestHandler(fuzzy="Card 1", rate_limit_per_second=5.0)
+
+        # Call _fetch_raw again on the same instance (simulates pagination)
+        start = time.time()
+        handler._fetch_raw(
+            "https://api.scryfall.com/cards/named?fuzzy=Card+2",
+            rate_limit=True,
+        )
+        elapsed = time.time() - start
+
+        # Should wait ~0.2s (5 calls/sec = 200ms interval)
+        assert elapsed > 0.15
 
     def test_slow_rate_limiter_attributes_via_global(
         self, mock_urlopen_with_rate_limit, sample_card


### PR DESCRIPTION
Scryfall API rate limit docs: https://scryfall.com/docs/api/rate-limits

## Summary

- Add per-endpoint rate limiting to comply with Scryfall tiered rate limits (2/s for search, named, random, collection; 10/s for all other endpoints)
- Introduce SlowRateLimiter subclass with 2.0 calls/second default
- Change RateLimiter singleton to per-class registry so each rate tier maintains independent state
- Add _rate_limiter_class to ScrythonRequestHandler so endpoint classes declare their rate tier
- No public API changes; existing rate_limit_per_second kwarg and rate_limit=False still work

## Test plan

- [x] SlowRateLimiter unit tests (default rate, 500ms timing enforcement)
- [x] Registry tests (per-class isolation, reset clears all tiers)
- [x] Integration tests (slow handler timing, kwarg override, class default)
- [x] Endpoint assignment tests (4 slow endpoints verified, 2 fast endpoints verified)
- [x] Full suite passes (410 passed, 1 pre-existing skip)