### PR TITLE
Ship PEP 561 Type Hint Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Scrython is a [PEP 561](https://peps.python.org/pep-0561/) compliant typed packa
 import scrython
 
 card = scrython.cards.Named(fuzzy="Lightning Bolt")
-reveal_type(card.name)  # Revealed type is "str"
+reveal_type(card.name)  # should reveal type `str` (mypy may display this as `builtins.str`)
 ```
 
 Run your type checker of choice against scrython imports and it will work out of the box:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ Scrython is available in PyPI, and requires no other dependencies.
 pip install scrython
 ```
 
+## Type Hints
+
+Scrython is a [PEP 561](https://peps.python.org/pep-0561/) compliant typed package. It ships a `py.typed` marker, so mypy, pyright, and Pylance all pick up the bundled inline type hints without any extra configuration or stub packages.
+
+```python
+import scrython
+
+card = scrython.cards.Named(fuzzy="Lightning Bolt")
+reveal_type(card.name)  # Revealed type is "str"
+```
+
+Run your type checker of choice against scrython imports and it will work out of the box:
+
+```bash
+mypy my_script.py      # or
+pyright my_script.py
+```
+
 ## ⚠️ Important: Rate Limiting
 
 **Good news!** Scrython 2.0 includes **built-in rate limiting** enabled by default. You no longer need to manually add delays between requests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ classifiers = [
 Homepage = "https://github.com/NandaScott/Scrython"
 Repository = "https://github.com/NandaScott/Scrython"
 
+[tool.setuptools.packages.find]
+include = ["scrython*"]
+
 [tool.setuptools.package-data]
 scrython = ["py.typed"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scrython"
-version = "2.0.3"
+version = "2.1.0"
 description = "A wrapper for using the Scryfall API."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -24,11 +24,15 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
 ]
 
 [project.urls]
 Homepage = "https://github.com/NandaScott/Scrython"
 Repository = "https://github.com/NandaScott/Scrython"
+
+[tool.setuptools.package-data]
+scrython = ["py.typed"]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Closes #164
Closes #166

# Description
This adds PEP 561 typing support to Scrython by shipping a `py.typed` marker and advertising it in the README.

Scrython already carries type annotations across the mixins and handlers, but without a `py.typed` marker in the installed package, downstream type checkers (mypy, pyright) silently ignore them. I added the marker and wired it through `[tool.setuptools.package-data]` so it actually lands in the built wheel, rather than leaning on a MANIFEST.in. I bumped the version to 2.1.0 since typed-package support is additive, so a SemVer-minor fits.

I also added a Type Hints section to the README, placed between Installation and Rate Limiting so new adopters see it before deciding to install. It names mypy and pyright/Pylance and shows a short `reveal_type` example.

Changes:
- Added `scrython/py.typed` marker for PEP 561 compliance.
- Wired the marker into the wheel via `[tool.setuptools.package-data]` in `pyproject.toml`.
- Added the `Typing :: Typed` PyPI classifier.
- Bumped the version from 2.0.3 to 2.1.0.
- Added a Type Hints section to `README.md` covering PEP 561, the bundled marker, and supported checkers.

## Testing
- [x] `ruff check .`
- [x] `mypy scrython`
- [x] `pytest -m "not integration"`
- [x] Manual verification needed

These ran inside the sandcastle sandbox during the agent run that produced commits #164 and #166.
