### PR TITLE
Add Sandcastle Agent Orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ dmypy.json
 # Python version
 .python-version
 docs/superpowers
+
+# Sandcastle Node tooling (project is Python; these come from @ai-hero/sandcastle)
+node_modules/
+package.json
+package-lock.json

--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -1,0 +1,7 @@
+# Anthropic API key
+# If you want to use your Claude subscription instead of an API key, see https://github.com/mattpocock/sandcastle/issues/191
+ANTHROPIC_API_KEY=
+# GitHub personal access token — the agent uses it to read and manage GitHub Issues
+# Create a fine-grained token: https://github.com/settings/personal-access-tokens/new
+# Required repository permissions: Issues (Read and write) and Metadata (Read)
+GH_TOKEN=

--- a/.sandcastle/.gitignore
+++ b/.sandcastle/.gitignore
@@ -1,0 +1,3 @@
+.env
+logs/
+worktrees/

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -1,0 +1,44 @@
+FROM python:3.12-bookworm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+  git \
+  curl \
+  jq \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && apt-get update && apt-get install -y gh \
+  && rm -rf /var/lib/apt/lists/*
+
+# Build-args for UID/GID alignment: sandcastle docker build-image
+# defaults these to the host user's UID/GID so image-built files
+# and bind-mounted files share an owner without runtime chown.
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+
+# The python base image has no unprivileged user, so create "agent"
+# with the host's UID/GID for clean ownership on the bind-mounted worktree.
+RUN groupadd -o -g $AGENT_GID agent \
+  && useradd -o -u $AGENT_UID -g $AGENT_GID -m -d /home/agent -s /bin/bash agent
+USER ${AGENT_UID}:${AGENT_GID}
+
+# Install uv (used for fast dependency installs) into the agent's local bin.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install Claude Code CLI
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Add uv and Claude to PATH
+ENV PATH="/home/agent/.local/bin:$PATH"
+
+WORKDIR /home/agent
+
+# In worktree sandbox mode, Sandcastle bind-mounts the git worktree at /home/agent/workspace
+# and overrides the working directory to /home/agent/workspace at container start.
+# Structure your Dockerfile so that /home/agent/workspace can serve as the project root.
+ENTRYPOINT ["sleep", "infinity"]

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -1,0 +1,48 @@
+import { run, claudeCode } from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+
+// Simple loop: an agent that picks open issues one by one and closes them.
+// Run this with: npx tsx .sandcastle/main.mts
+// Or add to package.json scripts: "sandcastle": "npx tsx .sandcastle/main.mts"
+
+await run({
+  // A name for this run, shown as a prefix in log output.
+  name: "worker",
+
+  // Sandbox provider — runs the agent inside an isolated container.
+  sandbox: docker(),
+
+  // The agent provider. Pass a model string to claudeCode() — sonnet balances
+  // capability and speed for most tasks. Switch to claude-opus-4-7 for harder
+  // problems, or claude-haiku-4-5-20251001 for speed.
+  agent: claudeCode("claude-sonnet-4-6"),
+
+  // Path to the prompt file. Shell expressions inside are evaluated inside the
+  // sandbox at the start of each iteration, so the agent always sees fresh data.
+  promptFile: "./.sandcastle/prompt.md",
+
+  // Maximum number of iterations (agent invocations) to run in a session.
+  // Each iteration works on a single issue. Increase this to process more issues
+  // per run, or set it to 1 for a single-shot mode.
+  maxIterations: 3,
+
+  // Branch strategy — merge-to-head creates a temporary branch for the agent
+  // to work on, then merges the result back to HEAD when the run completes.
+  // This is required when using copyToWorktree, since head mode bind-mounts
+  // the host directory directly (no worktree to copy into).
+  branchStrategy: { type: "merge-to-head" },
+
+  // No host-to-worktree copy: this is a Python project and the host .venv holds
+  // macOS binaries that won't run in the Linux sandbox. Dependencies are installed
+  // fresh inside the container by the onSandboxReady hook instead.
+
+  // Lifecycle hooks — commands grouped by where they run (host or sandbox).
+  hooks: {
+    sandbox: {
+      // onSandboxReady runs once after the sandbox is initialised and the repo is
+      // synced in, before the agent starts. Installs Scrython plus its dev tools
+      // (ruff, mypy, pytest) so the agent can verify its own changes.
+      onSandboxReady: [{ command: "pip install -e \".[dev]\"" }],
+    },
+  },
+});

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -1,0 +1,53 @@
+# Context
+
+## Open issues
+
+!`gh issue list --state open --label Sandcastle --limit 100 --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+
+The list above has already been filtered to issues ready for work. Do not run your own unfiltered query to find more issues — if the list is empty, there is nothing to do.
+
+## Recent RALPH commits (last 10)
+
+!`git log --oneline --grep="RALPH" -10`
+
+# Task
+
+You are RALPH — an autonomous coding agent working through issues one at a time.
+
+## Priority order
+
+Work on issues in this order:
+
+1. **Bug fixes** — broken behaviour affecting users
+2. **Tracer bullets** — thin end-to-end slices that prove an approach works
+3. **Polish** — improving existing functionality (error messages, UX, docs)
+4. **Refactors** — internal cleanups with no user-visible change
+
+Pick the highest-priority open issue that is not blocked by another open issue.
+
+## Workflow
+
+1. **Explore** — read the issue carefully. Pull in the parent PRD if referenced. Read the relevant source files and tests before writing any code.
+2. **Plan** — decide what to change and why. Keep the change as small as possible.
+3. **Execute** — use RGR (Red → Green → Repeat → Refactor): write a failing test first, then write the implementation to pass it.
+4. **Verify** — run `ruff check .`, `mypy scrython`, and `pytest -m "not integration"` before committing. Fix any failures before proceeding. (Integration tests need network and are skipped in the sandbox.)
+5. **Commit** — make a single git commit. The message MUST:
+   - Start with `RALPH:` prefix
+   - Include the task completed and any PRD reference
+   - List key decisions made
+   - List files changed
+   - Note any blockers for the next iteration
+6. **Close** — close the issue with `gh issue close <ID> --comment "Completed by Sandcastle"` explaining what was done.
+
+## Rules
+
+- Work on **one issue per iteration**. Do not attempt multiple issues in a single iteration.
+- Do not close an issue until you have committed the fix and verified tests pass.
+- Do not leave commented-out code or TODO comments in committed code.
+- If you are blocked (missing context, failing tests you cannot fix, external dependency), leave a comment on the issue and move on — do not close it.
+
+# Done
+
+When all actionable issues are complete (or you are blocked on all remaining ones), output the completion signal:
+
+<promise>COMPLETE</promise>


### PR DESCRIPTION
# Description
This adds sandcastle to the repo as a blocker-aware issue orchestrator: a run picks up open `ready-for-agent` issues, works each one in an isolated Docker sandbox, opens a PR, and relabels the issue to `needs-review`.

I started from sandcastle's `simple-loop` template but replaced it with a custom orchestrator modeled on my tubarr setup, adapted for this Python repo. The agent commits only; the host pushes, opens the PR, and relabels. That split fixes the thing I did not want from the template, where the agent closed issues itself before the work was reviewed.

The orchestrator reads the `## Blocked by` section of each issue and only dispatches one once every blocker it names is cleared. A blocker is cleared when its issue is closed or when the target branch already carries a commit referencing it (e.g. `(#170)`). That commit check is what lets PRD branches work: merging a slice into a `prd/<slug>` branch lands the commit but does not auto-close the issue, since auto-close only fires on the default branch. Issues with a milestone target their `prd/<slug>` branch; everything else targets `develop`. This matters for the connector series (#170 to #171 to #172/#173), where a later slice must never branch off a base that lacks the earlier slice's work.

The Docker image is Python-specific: `python:3.12` with `uv`, `gh`, and Claude Code, and a host-aligned `agent` user. The per-issue prompt runs `ruff`, `mypy`, and `pytest` as its gates. The agent model is Sonnet 4.6, which is enough for this repo and keeps API spend down.

Changes:
- Added `.sandcastle/` with the orchestrator (`main.mts`), per-issue prompt template, Dockerfile, and `.env.example`.
- Built the orchestrator around the `ready-for-agent` to `needs-review` label flow, one branch and PR per issue.
- Made dispatch respect each issue's `## Blocked by` list, clearing a blocker on issue-closed or a `(#N)` commit on the target branch.
- Routed milestone issues to a `prd/<slug>` branch (created from develop on first use) and everything else to develop.
- Adapted the Dockerfile to `python:3.12` + `uv` + `gh` + Claude Code and the prompt gates to `ruff`, `mypy`, `pytest`.
- Added `DRY_RUN=1` (print the plan, spawn nothing) and `ONLY_ISSUE=N` (single-issue smoke test) controls.
- Gitignored the npm-sourced Node files at the repo root.

## Testing
- [x] `sandcastle docker build-image` builds `sandcastle:scrython`
- [x] Smoke-tested the image: Python 3.12, uv, gh, and Claude Code all present
- [x] `DRY_RUN=1 npx tsx .sandcastle/main.mts` prints the correct dispatch plan and blocked list (#171 waits on #170; #172/#173 wait on #170 and #171)
- [x] Ran an earlier simple-loop version end-to-end on #164 and #166 with passing `ruff`, `mypy`, and `pytest` (that work is in #174)
