### PR TITLE
Make Sandcastle a Blocker-Aware Orchestrator

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -1,48 +1,310 @@
 import { run, claudeCode } from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
-// Simple loop: an agent that picks open issues one by one and closes them.
-// Run this with: npx tsx .sandcastle/main.mts
-// Or add to package.json scripts: "sandcastle": "npx tsx .sandcastle/main.mts"
+// Host orchestrator for Scrython. Works open issues labeled `ready-for-agent`,
+// one sandboxed agent per issue, fanned out in parallel. Each agent commits
+// only; the host pushes, opens a PR, and relabels the issue to `needs-review`.
+//
+// Unlike a plain fan-out, this respects the `## Blocked by` section in an issue
+// body: an issue is only dispatched once every blocker it names is cleared.
+// Scrython's connector series (#170 -> #171 -> #172/#173) relies on this so a
+// later slice never branches off a base that lacks the earlier slice's work.
 
-await run({
-  // A name for this run, shown as a prefix in log output.
-  name: "worker",
+const REPO = "NandaScott/Scrython";
+const AGENT_LABEL = "ready-for-agent";
+const DONE_LABEL = "needs-review";
+const IMAGE_NAME = "sandcastle:scrython";
+const MODEL = "claude-sonnet-4-6";
+const DEFAULT_BASE = "develop";
+const DRY_RUN = process.env.DRY_RUN === "1";
+const ONLY_ISSUE = process.env.ONLY_ISSUE ? Number(process.env.ONLY_ISSUE) : null;
 
-  // Sandbox provider — runs the agent inside an isolated container.
-  sandbox: docker(),
+const promptFile = fileURLToPath(new URL("./prompt.md", import.meta.url));
 
-  // The agent provider. Pass a model string to claudeCode() — sonnet balances
-  // capability and speed for most tasks. Switch to claude-opus-4-7 for harder
-  // problems, or claude-haiku-4-5-20251001 for speed.
-  agent: claudeCode("claude-sonnet-4-6"),
+interface Milestone {
+  readonly title: string;
+}
 
-  // Path to the prompt file. Shell expressions inside are evaluated inside the
-  // sandbox at the start of each iteration, so the agent always sees fresh data.
-  promptFile: "./.sandcastle/prompt.md",
+interface Issue {
+  readonly number: number;
+  readonly title: string;
+  readonly body: string;
+  readonly milestone: Milestone | null;
+}
 
-  // Maximum number of iterations (agent invocations) to run in a session.
-  // Each iteration works on a single issue. Increase this to process more issues
-  // per run, or set it to 1 for a single-shot mode.
-  maxIterations: 3,
+interface Plan {
+  readonly issue: Issue;
+  readonly target: string;
+}
 
-  // Branch strategy — merge-to-head creates a temporary branch for the agent
-  // to work on, then merges the result back to HEAD when the run completes.
-  // This is required when using copyToWorktree, since head mode bind-mounts
-  // the host directory directly (no worktree to copy into).
-  branchStrategy: { type: "merge-to-head" },
+interface Outcome {
+  readonly number: number;
+  readonly target: string;
+  readonly status: string;
+  readonly detail: string;
+}
 
-  // No host-to-worktree copy: this is a Python project and the host .venv holds
-  // macOS binaries that won't run in the Linux sandbox. Dependencies are installed
-  // fresh inside the container by the onSandboxReady hook instead.
+function git(...args: string[]): string {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
 
-  // Lifecycle hooks — commands grouped by where they run (host or sandbox).
-  hooks: {
-    sandbox: {
-      // onSandboxReady runs once after the sandbox is initialised and the repo is
-      // synced in, before the agent starts. Installs Scrython plus its dev tools
-      // (ruff, mypy, pytest) so the agent can verify its own changes.
-      onSandboxReady: [{ command: "pip install -e \".[dev]\"" }],
+function gh(...args: string[]): string {
+  return execFileSync("gh", args, { encoding: "utf8" }).trim();
+}
+
+function errorMessage(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
+
+function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function targetBranchFor(issue: Issue): string {
+  if (!issue.milestone) {
+    return DEFAULT_BASE;
+  }
+  return `prd/${slugify(issue.milestone.title)}`;
+}
+
+// Pull the issue numbers out of the `## Blocked by` section only, so a `## Parent`
+// reference (or any other `#N` in the body) is never mistaken for a blocker.
+function parseBlockers(body: string): number[] {
+  const section = body.match(/##\s*Blocked by\s*([\s\S]*?)(?:\n#{1,6}\s|$)/i);
+  if (!section) {
+    return [];
+  }
+  const numbers = [...section[1].matchAll(/#(\d+)/g)].map((match) => Number(match[1]));
+  return [...new Set(numbers)];
+}
+
+const issueStateCache = new Map<number, string>();
+
+function issueState(issueNumber: number): string {
+  const cached = issueStateCache.get(issueNumber);
+  if (cached) {
+    return cached;
+  }
+  const state = JSON.parse(
+    gh("issue", "view", String(issueNumber), "--repo", REPO, "--json", "state"),
+  ).state as string;
+  issueStateCache.set(issueNumber, state);
+  return state;
+}
+
+// A blocker is cleared when its issue is closed, or when the target base branch
+// already contains a commit that references it (e.g. `... (#170)`). The commit
+// check is what makes PRD-branch flows work: merging a slice's PR into a
+// `prd/<slug>` branch does not close the issue (auto-close only fires on the
+// default branch), but it does land a `(#N)` commit on the target.
+function blockerCleared(blocker: number, target: string): boolean {
+  if (issueState(blocker) === "CLOSED") {
+    return true;
+  }
+  try {
+    const log = execFileSync(
+      "git",
+      ["log", `origin/${target}`, `--grep=(#${blocker})`, "--oneline"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    return log.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function pendingBlockers(issue: Issue, target: string): number[] {
+  return parseBlockers(issue.body).filter((blocker) => !blockerCleared(blocker, target));
+}
+
+function remoteBranchExists(branch: string): boolean {
+  const out = execFileSync("git", ["ls-remote", "--heads", "origin", branch], {
+    encoding: "utf8",
+  });
+  return out.trim().length > 0;
+}
+
+function ensurePrdBranch(branch: string): void {
+  if (remoteBranchExists(branch)) {
+    console.log(`PRD branch exists: ${branch}`);
+    return;
+  }
+  if (DRY_RUN) {
+    console.log(`[dry-run] would create PRD branch ${branch} from origin/${DEFAULT_BASE}`);
+    return;
+  }
+  console.log(`Creating PRD branch ${branch} from origin/${DEFAULT_BASE}`);
+  git("push", "origin", `origin/${DEFAULT_BASE}:refs/heads/${branch}`);
+  git("fetch", "origin", `${branch}:${branch}`);
+}
+
+async function runIssue(plan: Plan) {
+  const branch = `sandcastle/issue-${plan.issue.number}`;
+  const result = await run({
+    agent: claudeCode(MODEL),
+    sandbox: docker({ imageName: IMAGE_NAME }),
+    branchStrategy: { type: "branch", branch, baseBranch: plan.target },
+    promptFile,
+    promptArgs: {
+      ISSUE_NUMBER: String(plan.issue.number),
+      ISSUE_TITLE: plan.issue.title,
+      ISSUE_BODY: plan.issue.body ?? "",
+      BASE_BRANCH: plan.target,
     },
-  },
+    name: `issue-${plan.issue.number}`,
+  });
+  return { plan, branch, result };
+}
+
+function openPullRequest(plan: Plan, branch: string, commitCount: number): Outcome {
+  try {
+    git("push", "origin", branch);
+    const prUrl = gh(
+      "pr",
+      "create",
+      "--repo",
+      REPO,
+      "--base",
+      plan.target,
+      "--head",
+      branch,
+      "--title",
+      plan.issue.title,
+      "--body",
+      `Closes #${plan.issue.number}\n\nOpened by Sandcastle. ${commitCount} commit(s) on \`${branch}\`.`,
+    );
+    gh(
+      "issue",
+      "edit",
+      String(plan.issue.number),
+      "--repo",
+      REPO,
+      "--remove-label",
+      AGENT_LABEL,
+      "--add-label",
+      DONE_LABEL,
+    );
+    return { number: plan.issue.number, target: plan.target, status: "PR opened", detail: prUrl };
+  } catch (err) {
+    return {
+      number: plan.issue.number,
+      target: plan.target,
+      status: "post-run failed",
+      detail: errorMessage(err),
+    };
+  }
+}
+
+function printSummary(outcomes: readonly Outcome[]): void {
+  console.log("\n=== Sandcastle run summary ===");
+  for (const outcome of outcomes) {
+    console.log(`#${outcome.number}  ${outcome.target}  ${outcome.status}  ${outcome.detail}`);
+  }
+}
+
+const allIssues: Issue[] = JSON.parse(
+  gh(
+    "issue",
+    "list",
+    "--repo",
+    REPO,
+    "--label",
+    AGENT_LABEL,
+    "--state",
+    "open",
+    "--json",
+    "number,title,body,milestone",
+  ),
+);
+
+const issues = ONLY_ISSUE ? allIssues.filter((i) => i.number === ONLY_ISSUE) : allIssues;
+
+if (ONLY_ISSUE && issues.length === 0) {
+  console.log(`Issue #${ONLY_ISSUE} is not open with label ${AGENT_LABEL}. Nothing to do.`);
+  process.exit(1);
+}
+
+if (issues.length === 0) {
+  console.log(`No open issues labeled ${AGENT_LABEL}. Nothing to do.`);
+  process.exit(0);
+}
+
+if (ONLY_ISSUE) {
+  console.log(`ONLY_ISSUE=${ONLY_ISSUE} — restricting this run to issue #${ONLY_ISSUE}.`);
+}
+
+git("fetch", "origin");
+
+// Ensure every PRD branch exists before resolving blockers, since a blocker can
+// be cleared by a `(#N)` commit already merged onto that branch.
+const targets = new Map(issues.map((issue) => [issue.number, targetBranchFor(issue)]));
+const prdBranches = [...new Set(targets.values())].filter((b) => b !== DEFAULT_BASE);
+for (const branch of prdBranches) {
+  ensurePrdBranch(branch);
+}
+if (prdBranches.length > 0 && !DRY_RUN) {
+  git("fetch", "origin");
+}
+
+const plans: Plan[] = [];
+const skipped: Outcome[] = [];
+for (const issue of issues) {
+  const target = targets.get(issue.number)!;
+  const pending = pendingBlockers(issue, target);
+  if (pending.length > 0) {
+    skipped.push({
+      number: issue.number,
+      target,
+      status: "blocked",
+      detail: `waiting on ${pending.map((n) => `#${n}`).join(", ")}`,
+    });
+    continue;
+  }
+  plans.push({ issue, target });
+}
+
+if (DRY_RUN) {
+  console.log("\n[dry-run] dispatch plan:");
+  for (const plan of plans) {
+    console.log(`  #${plan.issue.number} "${plan.issue.title}" -> ${plan.target}`);
+  }
+  printSummary(skipped);
+  process.exit(0);
+}
+
+if (plans.length === 0) {
+  console.log("\nEvery ready-for-agent issue is blocked. Nothing to dispatch this run.");
+  printSummary(skipped);
+  process.exit(0);
+}
+
+const settled = await Promise.allSettled(plans.map(runIssue));
+
+const dispatched: Outcome[] = settled.map((entry, index) => {
+  const plan = plans[index]!;
+  if (entry.status === "rejected") {
+    return {
+      number: plan.issue.number,
+      target: plan.target,
+      status: "failed",
+      detail: errorMessage(entry.reason),
+    };
+  }
+  const { branch, result } = entry.value;
+  if (result.commits.length === 0) {
+    return {
+      number: plan.issue.number,
+      target: plan.target,
+      status: "skipped",
+      detail: "agent produced no commits",
+    };
+  }
+  return openPullRequest(plan, branch, result.commits.length);
 });
+
+printSummary([...dispatched, ...skipped]);

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -304,6 +304,18 @@ const dispatched: Outcome[] = settled.map((entry, index) => {
       detail: "agent produced no commits",
     };
   }
+  // Open a PR only when the agent signaled completion. A missing
+  // completionSignal means it stopped before passing its gates (or hit the
+  // iteration limit), so its commits are partial. Leave the branch for review
+  // instead of opening a red PR.
+  if (!result.completionSignal) {
+    return {
+      number: plan.issue.number,
+      target: plan.target,
+      status: "incomplete",
+      detail: `agent did not signal completion; ${result.commits.length} commit(s) left on ${branch} for review`,
+    };
+  }
   return openPullRequest(plan, branch, result.commits.length);
 });
 

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -1,53 +1,44 @@
 # Context
 
-## Open issues
+You are an AFK coding agent working a single GitHub issue for the Scrython repo,
+inside an isolated sandbox on the branch `sandcastle/issue-{{ISSUE_NUMBER}}`,
+which is based on `{{BASE_BRANCH}}`. Your commits stay on this branch — the
+orchestrator handles pushing, opening the pull request, and relabeling the
+issue. Do not push, do not open a PR, do not edit labels, and do not touch
+`{{BASE_BRANCH}}` or any other branch.
 
-!`gh issue list --state open --label Sandcastle --limit 100 --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+Read the repo's `CLAUDE.md` and `Contributing.md` before writing code; they hold
+the architecture and the code-style rules and override your defaults.
 
-The list above has already been filtered to issues ready for work. Do not run your own unfiltered query to find more issues — if the list is empty, there is nothing to do.
+Repo context (run inside the sandbox):
 
-## Recent RALPH commits (last 10)
+!`git log --oneline -10`
 
-!`git log --oneline --grep="RALPH" -10`
+## Issue #{{ISSUE_NUMBER}} — {{ISSUE_TITLE}}
+
+{{ISSUE_BODY}}
 
 # Task
 
-You are RALPH — an autonomous coding agent working through issues one at a time.
+Implement issue #{{ISSUE_NUMBER}} on this branch:
 
-## Priority order
+1. Explore first. Read the issue carefully, pull in the parent PRD if it
+   references one, and read the relevant source and tests before writing code.
+2. Make the change, following `CLAUDE.md` and `Contributing.md`. Keep it as
+   small as the issue allows.
+3. Run the gates and make them pass:
+   - `ruff check .`
+   - `mypy scrython`
+   - `pytest -m "not integration"`
+   (Integration tests need network access and are skipped in the sandbox.)
+4. Commit your work with a clear message that references the issue, ending the
+   subject with `(#{{ISSUE_NUMBER}})`. Commit only — do not push.
 
-Work on issues in this order:
-
-1. **Bug fixes** — broken behaviour affecting users
-2. **Tracer bullets** — thin end-to-end slices that prove an approach works
-3. **Polish** — improving existing functionality (error messages, UX, docs)
-4. **Refactors** — internal cleanups with no user-visible change
-
-Pick the highest-priority open issue that is not blocked by another open issue.
-
-## Workflow
-
-1. **Explore** — read the issue carefully. Pull in the parent PRD if referenced. Read the relevant source files and tests before writing any code.
-2. **Plan** — decide what to change and why. Keep the change as small as possible.
-3. **Execute** — use RGR (Red → Green → Repeat → Refactor): write a failing test first, then write the implementation to pass it.
-4. **Verify** — run `ruff check .`, `mypy scrython`, and `pytest -m "not integration"` before committing. Fix any failures before proceeding. (Integration tests need network and are skipped in the sandbox.)
-5. **Commit** — make a single git commit. The message MUST:
-   - Start with `RALPH:` prefix
-   - Include the task completed and any PRD reference
-   - List key decisions made
-   - List files changed
-   - Note any blockers for the next iteration
-6. **Close** — close the issue with `gh issue close <ID> --comment "Completed by Sandcastle"` explaining what was done.
-
-## Rules
-
-- Work on **one issue per iteration**. Do not attempt multiple issues in a single iteration.
-- Do not close an issue until you have committed the fix and verified tests pass.
-- Do not leave commented-out code or TODO comments in committed code.
-- If you are blocked (missing context, failing tests you cannot fix, external dependency), leave a comment on the issue and move on — do not close it.
+If the issue is underspecified or cannot be completed cleanly, stop, leave the
+branch with whatever partial work is committed, and explain the blocker in your
+final message rather than guessing.
 
 # Done
 
-When all actionable issues are complete (or you are blocked on all remaining ones), output the completion signal:
-
-<promise>COMPLETE</promise>
+When the change is committed and the gates pass, output
+`<promise>COMPLETE</promise>` to signal completion.

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -26,11 +26,15 @@ Implement issue #{{ISSUE_NUMBER}} on this branch:
    references one, and read the relevant source and tests before writing code.
 2. Make the change, following `CLAUDE.md` and `Contributing.md`. Keep it as
    small as the issue allows.
-3. Run the gates and make them pass:
-   - `ruff check .`
+3. Run the gates and make them pass. These mirror CI (`.github/workflows/tests.yml`);
+   CI runs all of them on every push, so the PR is red until they pass:
+   - `black scrython tests` to format, then confirm `black --check scrython tests` is clean
+   - `ruff check scrython tests`
    - `mypy scrython`
    - `pytest -m "not integration"`
-   (Integration tests need network access and are skipped in the sandbox.)
+   Run them in this order — CI checks formatting first, so a stray unformatted line
+   fails the whole run before the tests even execute. Integration tests need network
+   access and are skipped here; CI runs the full `pytest` suite.
 4. Commit your work with a clear message that references the issue, ending the
    subject with `(#{{ISSUE_NUMBER}})`. Commit only — do not push.
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -333,6 +333,48 @@ I'll close it. The PR description is usually the first signal. If the prose read
 
 Reverse-engineered or undocumented Scryfall endpoints. Scrython tracks the [published Scryfall API](https://scryfall.com/docs/api). If a feature requires probing an internal endpoint, it does not belong here, regardless of how clean the implementation is.
 
+## Automated Contributions (Sandcastle)
+
+Some issues get worked by an agent instead of a person. I run [`@ai-hero/sandcastle`](https://github.com/mattpocock/sandcastle) from the `.sandcastle/` directory: it picks up issues labeled `ready-for-agent`, works each one in an isolated Docker sandbox, opens a pull request, and relabels the issue to `needs-review`. If you see a PR opened by Sandcastle, that is what produced it. It goes through the same review I give any contribution and has to pass the same gates.
+
+This is maintainer tooling. You do not need it to contribute, and running it needs an Anthropic API key plus write access to the repo. The notes below are here so the label flow and the agent-opened PRs are not a mystery, and so I have a runbook.
+
+### How a run works
+
+- One sandboxed agent per issue, fanned out in parallel. The agent commits only; the host pushes the branch, opens the PR, and swaps the label.
+- Dispatch respects the `## Blocked by` section of an issue. An issue is held until every blocker it names is cleared, where a blocker counts as cleared when its issue is closed or when the target branch already carries a commit referencing it. This keeps a dependent slice from branching off a base that lacks the work it builds on.
+- Issues attached to a milestone target a `prd/<slug>` branch created from `develop`; everything else targets `develop` directly.
+- The agent runs the same gates as CI (`black`, `ruff`, `mypy`, `pytest`), and the host opens a PR only once the agent signals it finished cleanly. A run that stalls leaves its branch for me to look at rather than opening a red PR.
+
+### One-time setup
+
+Sandcastle needs Docker and the npm package (the resulting `package.json`, `package-lock.json`, and `node_modules/` are gitignored at the repo root).
+
+1. Copy the env template and add your keys:
+
+   ```bash
+   cp .sandcastle/.env.example .sandcastle/.env
+   # set ANTHROPIC_API_KEY and GH_TOKEN
+   ```
+
+   `.sandcastle/.env` is gitignored. Never commit it.
+
+2. Build the sandbox image. Sandcastle's own command bakes the host UID/GID and tags the image the way the docker provider expects, so a plain `docker build` of the same name is not recognized:
+
+   ```bash
+   npx @ai-hero/sandcastle docker build-image
+   ```
+
+   Rebuild whenever `.sandcastle/Dockerfile` changes.
+
+### Running
+
+```bash
+npx tsx .sandcastle/main.mts                 # work all ready-for-agent issues
+DRY_RUN=1 npx tsx .sandcastle/main.mts       # print the dispatch plan; spawn nothing, write nothing
+ONLY_ISSUE=170 npx tsx .sandcastle/main.mts  # restrict to one issue (smoke test)
+```
+
 ## Before Submitting
 
 Before submitting a pull request, ensure:


### PR DESCRIPTION
# Description
This replaces the sandcastle `simple-loop` runner with a blocker-aware issue orchestrator. A run picks up open `ready-for-agent` issues, works each in an isolated Docker sandbox, opens a PR, and relabels the issue to `needs-review`.

The initial setup (PR #175) shipped the Python-adapted `simple-loop` template. This builds on it: the agent now commits only, and the host pushes, opens the PR, and relabels. That split fixes the behavior I did not want from the template, where the agent closed issues before the work was reviewed.

The orchestrator reads the `## Blocked by` section of each issue and only dispatches one once every blocker it names is cleared. A blocker is cleared when its issue is closed or when the target branch already carries a commit referencing it (e.g. `(#170)`). That commit check is what lets PRD branches work: merging a slice into a `prd/<slug>` branch lands the commit but does not auto-close the issue, since auto-close only fires on the default branch. Issues with a milestone target their `prd/<slug>` branch; everything else targets `develop`. This matters for the connector series (#170 to #171 to #172/#173), where a later slice must never branch off a base that lacks the earlier slice's work.

Two correctness fixes came out of the first live run. The agent's gates were missing `black`, which CI checks first, so #176 opened red even though the agent passed its own checks: the prompt gates now mirror CI exactly. And the host was opening a PR whenever the agent produced any commits, so I gated PR creation on the agent's completion signal (`RunResult.completionSignal`) so partial work leaves a branch for review instead of a red PR.

Changes:
- Replaced `main.mts` with a host orchestrator: list `ready-for-agent`, fan out one agent per issue, push, open a PR, relabel `ready-for-agent` to `needs-review`.
- Made dispatch respect each issue's `## Blocked by` list, clearing a blocker on issue-closed or a `(#N)` commit on the target branch.
- Routed milestone issues to a `prd/<slug>` branch (created from develop on first use) and everything else to develop.
- Gated PR creation on the agent's completion signal, so a stalled run leaves its branch for review rather than opening a red PR.
- Rewrote the prompt as a per-issue template whose gates mirror CI: `black`, `ruff check scrython tests`, `mypy`, `pytest`.
- Added `DRY_RUN=1` (print the plan, spawn nothing) and `ONLY_ISSUE=N` (single-issue smoke test) controls.
- Documented the runner in `Contributing.md`: the label flow, how a run works, setup, and the run commands.

## Testing
- [x] `DRY_RUN=1 npx tsx .sandcastle/main.mts` prints the correct dispatch plan and blocked list (#171 waits on #170; #172/#173 wait on #170 and #171)
- [x] `ONLY_ISSUE=170 npx tsx .sandcastle/main.mts` ran live end-to-end: created `prd/scryfallconnector-refactor`, the agent passed its gates and committed, the host opened #176 against the PRD branch and relabeled #170 to `needs-review`
- [x] #176 is green on 3.10/3.11/3.12 after the black gate fix landed on its branch
