### PR TITLE
Derive Sandcastle Branches From the Parent PRD

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -23,15 +23,10 @@ const ONLY_ISSUE = process.env.ONLY_ISSUE ? Number(process.env.ONLY_ISSUE) : nul
 
 const promptFile = fileURLToPath(new URL("./prompt.md", import.meta.url));
 
-interface Milestone {
-  readonly title: string;
-}
-
 interface Issue {
   readonly number: number;
   readonly title: string;
   readonly body: string;
-  readonly milestone: Milestone | null;
 }
 
 interface Plan {
@@ -65,11 +60,46 @@ function slugify(title: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
+// The integration branch comes from the slice's parent PRD, not a milestone:
+// a milestone groups several PRDs, so it is the wrong granularity for a branch.
+// The parent PRD reference lives in the issue's `## Parent` section.
+function parseParent(body: string): number | null {
+  const section = body.match(/##\s*Parent\s*([\s\S]*?)(?:\n#{1,6}\s|$)/i);
+  if (!section) {
+    return null;
+  }
+  const match = section[1].match(/#(\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
+// Turn a PRD issue title into a branch slug, dropping a leading `PRD:` and any
+// trailing parenthetical, so `PRD: ScryfallConnector refactor (PR 1 of a series)`
+// becomes `scryfallconnector-refactor`.
+function prdSlug(prdTitle: string): string {
+  const core = prdTitle.replace(/^\s*PRD:\s*/i, "").split("(")[0];
+  return slugify(core);
+}
+
+const issueTitleCache = new Map<number, string>();
+
+function issueTitle(issueNumber: number): string {
+  const cached = issueTitleCache.get(issueNumber);
+  if (cached) {
+    return cached;
+  }
+  const title = JSON.parse(
+    gh("issue", "view", String(issueNumber), "--repo", REPO, "--json", "title"),
+  ).title as string;
+  issueTitleCache.set(issueNumber, title);
+  return title;
+}
+
 function targetBranchFor(issue: Issue): string {
-  if (!issue.milestone) {
+  const parent = parseParent(issue.body);
+  if (parent === null) {
     return DEFAULT_BASE;
   }
-  return `prd/${slugify(issue.milestone.title)}`;
+  return `prd/${prdSlug(issueTitle(parent))}`;
 }
 
 // Pull the issue numbers out of the `## Blocked by` section only, so a `## Parent`
@@ -218,7 +248,7 @@ const allIssues: Issue[] = JSON.parse(
     "--state",
     "open",
     "--json",
-    "number,title,body,milestone",
+    "number,title,body",
   ),
 );
 


### PR DESCRIPTION
# Description
This changes how the Sandcastle orchestrator picks a slice's integration branch: it derives it from the slice's parent PRD instead of the issue's milestone.

I am moving to a hierarchy where a milestone is a release or epic that groups several PRDs, each PRD is an issue with its own `prd/<slug>` integration branch, and the implementable slices are sub-issues of the PRD. Under that model the milestone is the wrong granularity for a branch: a milestone holding three PRDs should not pile every slice onto one branch. So the orchestrator now reads the slice's `## Parent` reference, looks up that PRD's title, and derives `prd/<slug>` from it (dropping a leading `PRD:` and any trailing parenthetical). A slice with no parent still targets `develop`.

`## Parent` is the source of truth, independent of GitHub's native sub-issue links, since `gh` has no first-class sub-issue command and the text reference is stable to parse. This pairs with updates to the `to-prd` and `to-issues` skills: the PRD is published unlabeled (never `ready-for-agent`, so the orchestrator does not dispatch a planning doc), HITL slices get `ready-for-human` instead of `ready-for-agent`, and slices are filed as sub-issues of their PRD.

Changes:
- Derived the integration branch from the parent PRD (`parseParent` + `prdSlug` + a cached `issueTitle` lookup) rather than `issue.milestone`.
- Dropped the `Milestone` interface and stopped requesting the `milestone` field from `gh issue list`.

## Testing
- [x] `DRY_RUN=1 npx tsx .sandcastle/main.mts`: connector slices resolve to `prd/scryfallconnector-refactor` (parent #169) and PEP-561 slices to `prd/pep-561-compliance-ship-py-typed-marker` (parent #163); blocked list unchanged (#171 waits on #170; #172/#173 on #170 and #171)
