### PR TITLE
Support Issue Ranges and Lists in the Sandcastle ONLY_ISSUE Selector

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -19,7 +19,6 @@ const IMAGE_NAME = "sandcastle:scrython";
 const MODEL = "claude-sonnet-4-6";
 const DEFAULT_BASE = "develop";
 const DRY_RUN = process.env.DRY_RUN === "1";
-const ONLY_ISSUE = process.env.ONLY_ISSUE ? Number(process.env.ONLY_ISSUE) : null;
 
 const promptFile = fileURLToPath(new URL("./prompt.md", import.meta.url));
 
@@ -52,6 +51,45 @@ function gh(...args: string[]): string {
 function errorMessage(value: unknown): string {
   return value instanceof Error ? value.message : String(value);
 }
+
+// Parse the ONLY_ISSUE selector into a set of issue numbers. Accepts a single
+// number (`170`), a comma-separated list (`170,172,173`), an inclusive range
+// (`170-173`), or any mix (`170-172,180`). Returns null when unset, so the run
+// falls back to every ready-for-agent issue.
+function parseIssueSelection(raw: string | undefined): Set<number> | null {
+  if (!raw) {
+    return null;
+  }
+  const selected = new Set<number>();
+  for (const term of raw.split(",")) {
+    const trimmed = term.trim();
+    if (trimmed === "") {
+      continue;
+    }
+    const range = trimmed.match(/^(\d+)\s*-\s*(\d+)$/);
+    if (range) {
+      const start = Number(range[1]);
+      const end = Number(range[2]);
+      if (start > end) {
+        throw new Error(`ONLY_ISSUE range "${trimmed}" is descending; use low-high.`);
+      }
+      for (let issueNumber = start; issueNumber <= end; issueNumber++) {
+        selected.add(issueNumber);
+      }
+      continue;
+    }
+    if (!/^\d+$/.test(trimmed)) {
+      throw new Error(`ONLY_ISSUE term "${trimmed}" is not a number or range.`);
+    }
+    selected.add(Number(trimmed));
+  }
+  if (selected.size === 0) {
+    throw new Error(`ONLY_ISSUE="${raw}" selected no issues.`);
+  }
+  return selected;
+}
+
+const ONLY_ISSUES = parseIssueSelection(process.env.ONLY_ISSUE);
 
 function slugify(title: string): string {
   return title
@@ -252,10 +290,13 @@ const allIssues: Issue[] = JSON.parse(
   ),
 );
 
-const issues = ONLY_ISSUE ? allIssues.filter((i) => i.number === ONLY_ISSUE) : allIssues;
+const issues = ONLY_ISSUES
+  ? allIssues.filter((issue) => ONLY_ISSUES.has(issue.number))
+  : allIssues;
 
-if (ONLY_ISSUE && issues.length === 0) {
-  console.log(`Issue #${ONLY_ISSUE} is not open with label ${AGENT_LABEL}. Nothing to do.`);
+if (ONLY_ISSUES && issues.length === 0) {
+  const requested = [...ONLY_ISSUES].map((n) => `#${n}`).join(", ");
+  console.log(`None of ${requested} are open with label ${AGENT_LABEL}. Nothing to do.`);
   process.exit(1);
 }
 
@@ -264,8 +305,9 @@ if (issues.length === 0) {
   process.exit(0);
 }
 
-if (ONLY_ISSUE) {
-  console.log(`ONLY_ISSUE=${ONLY_ISSUE} — restricting this run to issue #${ONLY_ISSUE}.`);
+if (ONLY_ISSUES) {
+  const requested = [...ONLY_ISSUES].map((n) => `#${n}`).join(", ");
+  console.log(`ONLY_ISSUE — restricting this run to ${requested}.`);
 }
 
 git("fetch", "origin");

--- a/Contributing.md
+++ b/Contributing.md
@@ -370,10 +370,18 @@ Sandcastle needs Docker and the npm package (the resulting `package.json`, `pack
 ### Running
 
 ```bash
-npx tsx .sandcastle/main.mts                 # work all ready-for-agent issues
-DRY_RUN=1 npx tsx .sandcastle/main.mts       # print the dispatch plan; spawn nothing, write nothing
-ONLY_ISSUE=170 npx tsx .sandcastle/main.mts  # restrict to one issue (smoke test)
+npx tsx .sandcastle/main.mts                     # work all ready-for-agent issues
+DRY_RUN=1 npx tsx .sandcastle/main.mts           # print the dispatch plan; spawn nothing, write nothing
+ONLY_ISSUE=170 npx tsx .sandcastle/main.mts      # restrict to one issue (smoke test)
+ONLY_ISSUE=170-173 npx tsx .sandcastle/main.mts  # restrict to an inclusive range
+ONLY_ISSUE=170,172,173 npx tsx .sandcastle/main.mts  # restrict to a list
+ONLY_ISSUE=170-172,180 npx tsx .sandcastle/main.mts  # mix ranges and singles
 ```
+
+`ONLY_ISSUE` accepts a single number, an inclusive range (`170-173`), a
+comma-separated list, or any mix. A descending range or a non-numeric term is
+an error. Selected issues still resolve their own target branch and wait on
+their `## Blocked by` blockers, so the selector only narrows the candidate set.
 
 ## Before Submitting
 


### PR DESCRIPTION
# Description
This PR extends the Sandcastle orchestrator's `ONLY_ISSUE` selector so a single run can target a range or an arbitrary subset of issues instead of just one.

The selector previously took a single issue number, which meant restricting a run to a contiguous slice series (Scrython's connector chain, for example) was not possible without dispatching every `ready-for-agent` issue. The new parser accepts a comma-separated list, an inclusive range, or any mix of the two, and resolves them into a set of issue numbers that drives the existing filter. A bare number behaves exactly as before, so nothing already documented changes.

I kept the env var name `ONLY_ISSUE` rather than introducing a second variable. The selector grammar is small enough to live behind one name, and a new name would have left two overlapping knobs to reason about. Malformed input fails loudly: a descending range or a non-numeric term raises an error rather than silently selecting nothing and running against the full backlog.

Changes:
- Added a `parseIssueSelection` helper that turns `ONLY_ISSUE` into a `Set<number>`, accepting `170`, `170,172,173`, `170-173`, and mixes like `170-172,180`.
- Made descending ranges and non-numeric terms raise a clear error.
- Updated the issue filter and run-restriction logging to operate over the selected set.
- Documented the new syntax in the Sandcastle section of `Contributing.md`.

## Testing
- [x] Smoke-tested `parseIssueSelection` against single / list / range / mixed / whitespace / descending / non-numeric / empty inputs (Node 26 native type-strip).
