### PR TITLE
Packaging regression test: assert py.typed lands in built wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-cov>=4.1.0",
     "pre-commit>=3.6.0",
+    "build>=1.0.0",
 ]
 progress = [
     "tqdm>=4.65.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 [pytest]
 testpaths = tests
 pythonpath = .
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+    integration: marks tests that require network access

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.slow
+def test_py_typed_in_wheel():
+    repo_root = Path(__file__).parent.parent
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        subprocess.run(
+            [sys.executable, "-m", "build", "--wheel", "--outdir", tmp_dir],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+        )
+
+        wheels = list(Path(tmp_dir).glob("*.whl"))
+        assert len(wheels) == 1, f"Expected 1 wheel, found {len(wheels)}"
+
+        with zipfile.ZipFile(wheels[0]) as whl:
+            assert "scrython/py.typed" in whl.namelist()


### PR DESCRIPTION
Closes #167

Opened by Sandcastle. 1 commit(s) on `sandcastle/issue-167`.