### PR TITLE
Add Tags Object Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.1.0] - Unreleased
 
 ### Added
+- **`scrython.tags` module**: First-class `Tag` object model for the `art_tags` and `oracle_tags` bulk files. Download the bulk file through the existing `bulk_data.ByType(...).download()` path, then wrap each entry in `scrython.tags.Object` for typed accessors. The nested `taggings` array resolves into typed `scrython.tags.Tagging` objects, with one model covering both art (`illustration_id`) and oracle (`oracle_id`) taggings. Adds `ScryfallTagData` and `ScryfallTaggingData` to `scrython.types`.
 - **`py.typed` marker**: Scrython now ships a `py.typed` marker file, signaling to type checkers (mypy, pyright, etc.) that the package supports PEP 561 inline type hints. The `Typing :: Typed` PyPI classifier has also been added to `pyproject.toml`.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2.1.0] - Unreleased
+## [2.2.0] - Unreleased
 
 ### Added
 - **`scrython.tags` module**: First-class `Tag` object model for the `art_tags` and `oracle_tags` bulk files. Download the bulk file through the existing `bulk_data.ByType(...).download()` path, then wrap each entry in `scrython.tags.Object` for typed accessors. The nested `taggings` array resolves into typed `scrython.tags.Tagging` objects, with one model covering both art (`illustration_id`) and oracle (`oracle_id`) taggings. Adds `ScryfallTagData` and `ScryfallTaggingData` to `scrython.types`.
+
+---
+
+## [2.1.0] - Unreleased
+
+### Added
 - **`py.typed` marker**: Scrython now ships a `py.typed` marker file, signaling to type checkers (mypy, pyright, etc.) that the package supports PEP 561 inline type hints. The `Typing :: Typed` PyPI classifier has also been added to `pyproject.toml`.
 
 ---

--- a/README.md
+++ b/README.md
@@ -261,9 +261,30 @@ cards = oracle_cards.download(progress=True)
 # - 'default_cards': One version of each card
 # - 'all_cards': All card printings
 # - 'rulings': All card rulings
+# - 'art_tags': Community art tags from Scryfall Tagger
+# - 'oracle_tags': Community oracle tags from Scryfall Tagger
 ```
 
 **Note:** The `download()` method automatically detects whether responses are gzip-compressed by checking HTTP `Content-Encoding` headers. This means it works seamlessly regardless of Scryfall's CDN configuration - you don't need to worry about compression formats.
+
+### Tags
+
+The `art_tags` and `oracle_tags` bulk files come from [Scryfall Tagger](https://tagger.scryfall.com). Tags have no dedicated API endpoint, so download the bulk file through `bulk_data.ByType(...).download()` and wrap each entry in `scrython.tags.Object` for typed property access. The nested `taggings` array resolves into typed `Tagging` objects.
+
+```python
+import scrython
+
+bulk = scrython.bulk_data.ByType(type='oracle_tags')
+tags = [scrython.tags.Object(tag) for tag in bulk.download()]
+
+tags[0].label                  # e.g. "removal"
+tags[0].type                   # "oracle"
+tags[0].id                     # stable UUID
+
+# Oracle taggings carry an oracle_id; art taggings carry an illustration_id
+for tagging in tags[0].taggings:
+    print(tagging.oracle_id, tagging.weight)
+```
 
 ### Error Handling
 

--- a/scrython/__init__.py
+++ b/scrython/__init__.py
@@ -1,3 +1,12 @@
-from . import bulk_data, cards, catalogs, migrations, rulings, sets, symbology
+from . import bulk_data, cards, catalogs, migrations, rulings, sets, symbology, tags
 
-__all__ = ["bulk_data", "cards", "catalogs", "migrations", "rulings", "sets", "symbology"]
+__all__ = [
+    "bulk_data",
+    "cards",
+    "catalogs",
+    "migrations",
+    "rulings",
+    "sets",
+    "symbology",
+    "tags",
+]

--- a/scrython/bulk_data/bulk_data.py
+++ b/scrython/bulk_data/bulk_data.py
@@ -80,7 +80,7 @@ class ByType(BulkDataObjectMixin, ScrythonRequestHandler[ScryfallBulkDataData]):
     Args:
         type: The bulk data type (required).
             Common types: 'oracle_cards', 'unique_artwork', 'default_cards',
-                         'all_cards', 'rulings'
+                         'all_cards', 'rulings', 'art_tags', 'oracle_tags'
 
     Example:
         # Get Oracle Cards bulk data
@@ -94,6 +94,11 @@ class ByType(BulkDataObjectMixin, ScrythonRequestHandler[ScryfallBulkDataData]):
         response = requests.get(oracle.download_uri)
         cards = response.json()
         print(f"Downloaded {len(cards)} cards")
+
+        # Download a tag bulk file and wrap each entry in a typed Tag object
+        bulk = scrython.bulk_data.ByType(type='oracle_tags')
+        tags = [scrython.tags.Object(t) for t in bulk.download()]
+        print(tags[0].label, tags[0].type)
 
     See: https://scryfall.com/docs/api/bulk-data/type
     """

--- a/scrython/tags/__init__.py
+++ b/scrython/tags/__init__.py
@@ -1,0 +1,3 @@
+from .tags import Object, Tagging
+
+__all__ = ["Object", "Tagging"]

--- a/scrython/tags/tags.py
+++ b/scrython/tags/tags.py
@@ -1,0 +1,32 @@
+from ..types import ScryfallTagData, ScryfallTaggingData
+from .tags_mixins import TaggingObjectMixin, TagObjectMixin
+
+
+class Tagging(TaggingObjectMixin):
+    """
+    Wrapper class for individual tagging objects nested within a Tag.
+
+    A tagging links a tag to a single card, by illustration for art tags or by
+    oracle identity for oracle tags. Provides access to all tagging properties
+    through TaggingObjectMixin.
+    """
+
+    def __init__(self, data: ScryfallTaggingData) -> None:
+        self._scryfall_data = data
+
+
+class Object(TagObjectMixin):
+    """
+    Wrapper class for individual tag objects from the Scryfall bulk files.
+
+    Tags are not served from a dedicated API endpoint. Download the art_tags or
+    oracle_tags bulk file through the generic bulk_data path, then wrap each entry:
+
+        bulk = scrython.bulk_data.ByType(type="oracle_tags")
+        tags = [scrython.tags.Object(t) for t in bulk.download()]
+
+    Provides access to all tag properties through TagObjectMixin.
+    """
+
+    def __init__(self, data: ScryfallTagData) -> None:
+        self._scryfall_data = data

--- a/scrython/tags/tags_mixins.py
+++ b/scrython/tags/tags_mixins.py
@@ -1,0 +1,164 @@
+from typing import Any
+
+from ..types import ScryfallTagData, ScryfallTaggingData
+from ..utils import to_object_array
+
+
+class TaggingObjectMixin:
+    """Provides property accessors for tagging objects nested in a Tag."""
+
+    _scryfall_data: ScryfallTaggingData
+
+    @property
+    def object(self) -> str:
+        """
+        A content type for this object, always "tagging".
+
+        Type: String (Required)
+        """
+        return "tagging"
+
+    @property
+    def weight(self) -> str:
+        """
+        How strongly this tagging applies. One of "very_strong", "strong",
+        "median", or "weak".
+
+        Type: String (Required)
+        """
+        return self._scryfall_data["weight"]
+
+    @property
+    def illustration_id(self) -> str | None:
+        """
+        The illustration this tagging applies to, present on art taggings.
+
+        Type: UUID (Nullable)
+        """
+        return self._scryfall_data.get("illustration_id")
+
+    @property
+    def oracle_id(self) -> str | None:
+        """
+        The Oracle identity this tagging applies to, present on oracle taggings.
+
+        Type: UUID (Nullable)
+        """
+        return self._scryfall_data.get("oracle_id")
+
+    @property
+    def annotation(self) -> str | None:
+        """
+        A human-readable note describing why the tag applies.
+
+        Type: String (Nullable)
+        """
+        return self._scryfall_data.get("annotation")
+
+
+class TagObjectMixin:
+    """Provides property accessors for tag objects from the Scryfall bulk files."""
+
+    _scryfall_data: ScryfallTagData
+
+    @property
+    def object(self) -> str:
+        """
+        A content type for this object, always "tag".
+
+        Type: String (Required)
+        """
+        return "tag"
+
+    @property
+    def id(self) -> str:
+        """
+        A stable, unique identifier for this tag.
+
+        Type: UUID (Required)
+        """
+        return self._scryfall_data["id"]
+
+    @property
+    def slug(self) -> str:
+        """
+        The URL-safe identifier for this tag.
+
+        Type: String (Required)
+        """
+        return self._scryfall_data["slug"]
+
+    @property
+    def label(self) -> str:
+        """
+        The human-readable name of this tag.
+
+        Type: String (Required)
+        """
+        return self._scryfall_data["label"]
+
+    @property
+    def uri(self) -> str:
+        """
+        A link to a Scryfall search for cards carrying this tag.
+
+        Type: URI (Required)
+        """
+        return self._scryfall_data["uri"]
+
+    @property
+    def type(self) -> str:
+        """
+        The kind of tag. Either "illustration" (art tag) or "oracle".
+
+        Type: String (Required)
+        """
+        return self._scryfall_data["type"]
+
+    @property
+    def description(self) -> str | None:
+        """
+        A description of what this tag represents.
+
+        Type: String (Nullable)
+        """
+        return self._scryfall_data.get("description")
+
+    @property
+    def parent_ids(self) -> list[str] | None:
+        """
+        The IDs of tags this tag is a child of.
+
+        Type: Array of UUIDs (Nullable)
+        """
+        return self._scryfall_data.get("parent_ids")
+
+    @property
+    def child_ids(self) -> list[str] | None:
+        """
+        The IDs of tags that are children of this tag.
+
+        Type: Array of UUIDs (Nullable)
+        """
+        return self._scryfall_data.get("child_ids")
+
+    @property
+    def aliases(self) -> list[str] | None:
+        """
+        Alternate names for this tag.
+
+        Type: Array of Strings (Nullable)
+        """
+        return self._scryfall_data.get("aliases")
+
+    @property
+    def taggings(self) -> list[Any] | None:
+        """
+        The Tagging objects linking this tag to individual cards.
+
+        Type: Array of Tagging objects
+        """
+        # Imported lazily to avoid a circular import: tags.py imports this mixin.
+        from .tags import Tagging
+
+        return to_object_array(Tagging, "taggings", self._scryfall_data)

--- a/scrython/tags/tags_mixins.py
+++ b/scrython/tags/tags_mixins.py
@@ -10,28 +10,9 @@ class TaggingObjectMixin:
     _scryfall_data: ScryfallTaggingData
 
     @property
-    def object(self) -> str:
-        """
-        A content type for this object, always "tagging".
-
-        Type: String (Required)
-        """
-        return "tagging"
-
-    @property
-    def weight(self) -> str:
-        """
-        How strongly this tagging applies. One of "very_strong", "strong",
-        "median", or "weak".
-
-        Type: String (Required)
-        """
-        return self._scryfall_data["weight"]
-
-    @property
     def illustration_id(self) -> str | None:
         """
-        The illustration this tagging applies to, present on art taggings.
+        For art tags: the illustration_id of the card artwork that has this tagging.
 
         Type: UUID (Nullable)
         """
@@ -40,16 +21,28 @@ class TaggingObjectMixin:
     @property
     def oracle_id(self) -> str | None:
         """
-        The Oracle identity this tagging applies to, present on oracle taggings.
+        For oracle tags: the oracle_id of the card that has this tagging.
 
         Type: UUID (Nullable)
         """
         return self._scryfall_data.get("oracle_id")
 
     @property
+    def weight(self) -> str:
+        """
+        How prominently the tag applies to this card. One of "very_strong" (the
+        subject is exemplary for the image or card text), "strong" (a primary
+        focus), "median" (a normal tagging with no special weight), or "weak"
+        (a minor detail or background element).
+
+        Type: String (Required)
+        """
+        return self._scryfall_data["weight"]
+
+    @property
     def annotation(self) -> str | None:
         """
-        A human-readable note describing why the tag applies.
+        An optional note providing additional context for this specific tagging.
 
         Type: String (Nullable)
         """
@@ -73,7 +66,7 @@ class TagObjectMixin:
     @property
     def id(self) -> str:
         """
-        A stable, unique identifier for this tag.
+        A unique and stable UUID for this tag.
 
         Type: UUID (Required)
         """
@@ -82,7 +75,8 @@ class TagObjectMixin:
     @property
     def slug(self) -> str:
         """
-        The URL-safe identifier for this tag.
+        A URL-safe identifier for the tag, e.g. "squirrel". Slugs may change over
+        time; use id as a stable reference.
 
         Type: String (Required)
         """
@@ -91,7 +85,7 @@ class TagObjectMixin:
     @property
     def label(self) -> str:
         """
-        The human-readable name of this tag.
+        A human-readable name for this tag, e.g. "Squirrel".
 
         Type: String (Required)
         """
@@ -100,7 +94,7 @@ class TagObjectMixin:
     @property
     def uri(self) -> str:
         """
-        A link to a Scryfall search for cards carrying this tag.
+        A link to this tag on the Tagger site.
 
         Type: URI (Required)
         """
@@ -109,7 +103,7 @@ class TagObjectMixin:
     @property
     def type(self) -> str:
         """
-        The kind of tag. Either "illustration" (art tag) or "oracle".
+        The tag type: "illustration" for art tags or "oracle" for oracle tags.
 
         Type: String (Required)
         """
@@ -118,7 +112,7 @@ class TagObjectMixin:
     @property
     def description(self) -> str | None:
         """
-        A description of what this tag represents.
+        An optional description of what this tag represents.
 
         Type: String (Nullable)
         """
@@ -127,38 +121,41 @@ class TagObjectMixin:
     @property
     def parent_ids(self) -> list[str] | None:
         """
-        The IDs of tags this tag is a child of.
+        UUIDs of parent tags in the tag hierarchy within this bulk file.
 
-        Type: Array of UUIDs (Nullable)
+        Type: Array (Nullable)
         """
         return self._scryfall_data.get("parent_ids")
 
     @property
     def child_ids(self) -> list[str] | None:
         """
-        The IDs of tags that are children of this tag.
+        UUIDs of child tags in the tag hierarchy within this bulk file.
 
-        Type: Array of UUIDs (Nullable)
+        Type: Array (Nullable)
         """
         return self._scryfall_data.get("child_ids")
 
     @property
     def aliases(self) -> list[str] | None:
         """
-        Alternate names for this tag.
+        Alternative names the community uses for this tag.
 
-        Type: Array of Strings (Nullable)
+        Type: Array (Nullable)
         """
         return self._scryfall_data.get("aliases")
 
     @property
-    def taggings(self) -> list[Any] | None:
+    def taggings(self) -> list[Any]:
         """
-        The Tagging objects linking this tag to individual cards.
+        An array of tagging objects associating this tag with specific cards.
 
-        Type: Array of Tagging objects
+        Type: Array (Required)
         """
         # Imported lazily to avoid a circular import: tags.py imports this mixin.
         from .tags import Tagging
 
-        return to_object_array(Tagging, "taggings", self._scryfall_data)
+        # taggings is a required field; return an empty list rather than None when
+        # the key is absent so callers can always iterate without a None check.
+        taggings = to_object_array(Tagging, "taggings", self._scryfall_data)
+        return taggings if taggings is not None else []

--- a/scrython/tags/tags_mixins.py
+++ b/scrython/tags/tags_mixins.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from ..types import ScryfallTagData, ScryfallTaggingData
-from ..utils import to_object_array
 
 
 class TaggingObjectMixin:
@@ -30,10 +29,12 @@ class TaggingObjectMixin:
     @property
     def weight(self) -> str:
         """
-        How prominently the tag applies to this card. One of "very_strong" (the
-        subject is exemplary for the image or card text), "strong" (a primary
-        focus), "median" (a normal tagging with no special weight), or "weak"
-        (a minor detail or background element).
+        How prominently the tag applies to this card. One of:
+
+        - "very_strong": the subject is exemplary for the image or card text.
+        - "strong": the subject is a primary focus of the image or card text.
+        - "median": a normal tagging with no special weight applied.
+        - "weak": the subject is a minor detail or background element.
 
         Type: String (Required)
         """
@@ -149,13 +150,11 @@ class TagObjectMixin:
     def taggings(self) -> list[Any]:
         """
         An array of tagging objects associating this tag with specific cards.
+        Present on every tag; an empty array when the tag has no direct taggings.
 
         Type: Array (Required)
         """
         # Imported lazily to avoid a circular import: tags.py imports this mixin.
         from .tags import Tagging
 
-        # taggings is a required field; return an empty list rather than None when
-        # the key is absent so callers can always iterate without a None check.
-        taggings = to_object_array(Tagging, "taggings", self._scryfall_data)
-        return taggings if taggings is not None else []
+        return [Tagging(tagging) for tagging in self._scryfall_data["taggings"]]

--- a/scrython/tags/tags_mixins.py
+++ b/scrython/tags/tags_mixins.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from ..types import ScryfallTagData, ScryfallTaggingData
+from ..utils import to_object_array
 
 
 class TaggingObjectMixin:
@@ -147,14 +148,13 @@ class TagObjectMixin:
         return self._scryfall_data.get("aliases")
 
     @property
-    def taggings(self) -> list[Any]:
+    def taggings(self) -> list[Any] | None:
         """
         An array of tagging objects associating this tag with specific cards.
-        Present on every tag; an empty array when the tag has no direct taggings.
 
         Type: Array (Required)
         """
         # Imported lazily to avoid a circular import: tags.py imports this mixin.
         from .tags import Tagging
 
-        return [Tagging(tagging) for tagging in self._scryfall_data["taggings"]]
+        return to_object_array(Tagging, "taggings", self._scryfall_data)

--- a/scrython/types.py
+++ b/scrython/types.py
@@ -333,6 +333,39 @@ class ScryfallRulingData(TypedDict):
     comment: str
 
 
+class ScryfallTaggingData(TypedDict):
+    """
+    TypedDict for a Scryfall Tagging object (an entry in a Tag's taggings array).
+
+    A tagging links a Tag to a single card, by illustration for art tags or by
+    oracle identity for oracle tags.
+    """
+
+    object: str
+    weight: str
+    illustration_id: NotRequired[UUID]
+    oracle_id: NotRequired[UUID]
+    annotation: NotRequired[str]
+
+
+class ScryfallTagData(TypedDict):
+    """
+    TypedDict for a Scryfall Tag object from the art_tags / oracle_tags bulk files.
+    """
+
+    object: str
+    id: UUID
+    slug: str
+    label: str
+    uri: URI
+    type: str
+    taggings: list[ScryfallTaggingData]
+    description: NotRequired[str]
+    parent_ids: NotRequired[list[UUID]]
+    child_ids: NotRequired[list[UUID]]
+    aliases: NotRequired[list[str]]
+
+
 class ScryfallMigrationData(TypedDict):
     """
     TypedDict for a Scryfall Migration object.

--- a/scrython/types.py
+++ b/scrython/types.py
@@ -341,7 +341,6 @@ class ScryfallTaggingData(TypedDict):
     oracle identity for oracle tags.
     """
 
-    object: str
     weight: str
     illustration_id: NotRequired[UUID]
     oracle_id: NotRequired[UUID]

--- a/tests/fixtures/tags/art_tag.json
+++ b/tests/fixtures/tags/art_tag.json
@@ -1,0 +1,21 @@
+{
+  "object": "tag",
+  "id": "e4444444-4444-4444-4444-444444444444",
+  "slug": "squirrel",
+  "label": "Squirrel",
+  "uri": "https://api.scryfall.com/cards/art-tag/squirrel",
+  "type": "illustration",
+  "taggings": [
+    {
+      "object": "tagging",
+      "illustration_id": "9c1f0a2b-5678-4d12-9e2c-ec6d9a345789",
+      "weight": "median",
+      "annotation": "A squirrel perches on Chatterfang's shoulder."
+    },
+    {
+      "object": "tagging",
+      "illustration_id": "aa2f0a2b-5678-4d12-9e2c-ec6d9a34578a",
+      "weight": "weak"
+    }
+  ]
+}

--- a/tests/fixtures/tags/art_tag.json
+++ b/tests/fixtures/tags/art_tag.json
@@ -1,21 +1,25 @@
 {
   "object": "tag",
-  "id": "e4444444-4444-4444-4444-444444444444",
-  "slug": "squirrel",
-  "label": "Squirrel",
-  "uri": "https://api.scryfall.com/cards/art-tag/squirrel",
+  "id": "3d1b2689-29ff-41d0-9ff1-b7ae18d1edb6",
+  "label": "mirri (housecat)",
+  "slug": "mirri-housecat",
   "type": "illustration",
+  "uri": "https://tagger.scryfall.com/tags/artwork/mirri-housecat",
+  "description": "Sami's cat.",
+  "parent_ids": [
+    "504aea75-b144-4530-b014-3e3c7a1fd283",
+    "7b155ecc-bd5e-4757-bde2-c029b6978bad",
+    "b8ad94e6-a042-49ff-bf9e-b963ade6e176",
+    "b88f1b22-c601-4e52-ae99-1fc602c65534"
+  ],
+  "child_ids": [],
+  "aliases": [
+    "mirri (cat)"
+  ],
   "taggings": [
     {
-      "object": "tagging",
-      "illustration_id": "9c1f0a2b-5678-4d12-9e2c-ec6d9a345789",
-      "weight": "median",
-      "annotation": "A squirrel perches on Chatterfang's shoulder."
-    },
-    {
-      "object": "tagging",
-      "illustration_id": "aa2f0a2b-5678-4d12-9e2c-ec6d9a34578a",
-      "weight": "weak"
+      "illustration_id": "d7a21c80-7157-4965-b6d0-d1f6ba0aec33",
+      "weight": "median"
     }
   ]
 }

--- a/tests/fixtures/tags/oracle_tag.json
+++ b/tests/fixtures/tags/oracle_tag.json
@@ -1,28 +1,37 @@
 {
   "object": "tag",
-  "id": "b7c19924-b4bf-492b-9c98-1e9b0f6e4d3a",
-  "slug": "removal",
-  "label": "Removal",
-  "uri": "https://api.scryfall.com/cards/oracle-tag/removal",
+  "id": "5bf7154a-2814-4329-a310-4a1343ee3850",
+  "label": "bottom deck manipulation",
+  "slug": "bottom-deck-manipulation",
   "type": "oracle",
-  "description": "Cards that destroy, exile, or otherwise remove permanents from the battlefield.",
-  "parent_ids": ["a1111111-1111-1111-1111-111111111111"],
-  "child_ids": [
-    "c2222222-2222-2222-2222-222222222222",
-    "d3333333-3333-3333-3333-333333333333"
+  "uri": "https://tagger.scryfall.com/tags/card/bottom-deck-manipulation",
+  "description": null,
+  "parent_ids": [
+    "f2486826-9b36-4aba-88bb-c2482e72f9ec"
   ],
-  "aliases": ["interaction", "answers"],
+  "child_ids": [
+    "296e1941-a9ba-4c6e-9548-c1efe2d67a8f",
+    "762d88d7-49f6-4af9-8442-247e350ba6ca",
+    "9c30f011-97e4-457e-ba5c-94238d346cdc"
+  ],
+  "aliases": [],
   "taggings": [
     {
-      "object": "tagging",
-      "oracle_id": "f2b9983e-20d4-4d12-9e2c-ec6d9a345787",
-      "weight": "strong",
-      "annotation": "Doom Blade destroys a nonblack creature."
+      "oracle_id": "97024e8e-dfde-4769-bc27-c3d6fad19e7c",
+      "weight": "median",
+      "annotation": "If you play this with a deck that can make tokens and has no creatures, you can reorder your entire deck."
     },
     {
-      "object": "tagging",
-      "oracle_id": "0f8f7d3e-1234-4d12-9e2c-ec6d9a345788",
-      "weight": "very_strong"
+      "oracle_id": "eccc9a54-2b56-4a02-9926-258d5b2e25fb",
+      "weight": "median"
+    },
+    {
+      "oracle_id": "2c132e6f-2e9e-4b39-81a8-f88c32173cd5",
+      "weight": "median"
+    },
+    {
+      "oracle_id": "2251e34e-4ce8-4452-9dc6-d8cce8583996",
+      "weight": "median"
     }
   ]
 }

--- a/tests/fixtures/tags/oracle_tag.json
+++ b/tests/fixtures/tags/oracle_tag.json
@@ -1,0 +1,28 @@
+{
+  "object": "tag",
+  "id": "b7c19924-b4bf-492b-9c98-1e9b0f6e4d3a",
+  "slug": "removal",
+  "label": "Removal",
+  "uri": "https://api.scryfall.com/cards/oracle-tag/removal",
+  "type": "oracle",
+  "description": "Cards that destroy, exile, or otherwise remove permanents from the battlefield.",
+  "parent_ids": ["a1111111-1111-1111-1111-111111111111"],
+  "child_ids": [
+    "c2222222-2222-2222-2222-222222222222",
+    "d3333333-3333-3333-3333-333333333333"
+  ],
+  "aliases": ["interaction", "answers"],
+  "taggings": [
+    {
+      "object": "tagging",
+      "oracle_id": "f2b9983e-20d4-4d12-9e2c-ec6d9a345787",
+      "weight": "strong",
+      "annotation": "Doom Blade destroys a nonblack creature."
+    },
+    {
+      "object": "tagging",
+      "oracle_id": "0f8f7d3e-1234-4d12-9e2c-ec6d9a345788",
+      "weight": "very_strong"
+    }
+  ]
+}

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,93 @@
+"""Tests for scrython.tags module."""
+
+import json
+from pathlib import Path
+
+import scrython
+
+FIXTURES = Path(__file__).parent / "fixtures" / "tags"
+
+
+def load_fixture(name: str) -> dict:
+    with open(FIXTURES / name) as f:
+        return json.load(f)
+
+
+class TestTagObject:
+    """Test the Tag Object wrapper."""
+
+    def test_shallow_import(self):
+        """scrython.tags.Object is reachable without a deep import."""
+        tag = scrython.tags.Object(load_fixture("oracle_tag.json"))
+        assert tag.object == "tag"
+
+    def test_scalar_accessors(self):
+        """Tag accessors return expected scalar values for a bulk tag dict."""
+        tag = scrython.tags.Object(load_fixture("oracle_tag.json"))
+
+        assert tag.id == "b7c19924-b4bf-492b-9c98-1e9b0f6e4d3a"
+        assert tag.slug == "removal"
+        assert tag.label == "Removal"
+        assert tag.uri == "https://api.scryfall.com/cards/oracle-tag/removal"
+        assert tag.type == "oracle"
+        assert tag.description.startswith("Cards that destroy")
+
+    def test_nullable_list_accessors(self):
+        """Nullable list accessors return their values when present."""
+        tag = scrython.tags.Object(load_fixture("oracle_tag.json"))
+
+        assert tag.parent_ids == ["a1111111-1111-1111-1111-111111111111"]
+        assert tag.child_ids == [
+            "c2222222-2222-2222-2222-222222222222",
+            "d3333333-3333-3333-3333-333333333333",
+        ]
+        assert tag.aliases == ["interaction", "answers"]
+
+    def test_absent_nullable_fields_return_none(self):
+        """Nullable fields return None when absent rather than raising."""
+        tag = scrython.tags.Object(load_fixture("art_tag.json"))
+
+        assert tag.description is None
+        assert tag.parent_ids is None
+        assert tag.child_ids is None
+        assert tag.aliases is None
+
+
+class TestTaggings:
+    """Test the nested Tagging wrapper."""
+
+    def test_taggings_returns_tagging_list(self):
+        """tag.taggings resolves into a list of Tagging objects."""
+        tag = scrython.tags.Object(load_fixture("oracle_tag.json"))
+
+        assert isinstance(tag.taggings, list)
+        assert all(isinstance(t, scrython.tags.Tagging) for t in tag.taggings)
+        assert len(tag.taggings) == 2
+
+    def test_oracle_tagging_shape(self):
+        """Oracle taggings expose oracle_id; illustration_id is None."""
+        tag = scrython.tags.Object(load_fixture("oracle_tag.json"))
+        tagging = tag.taggings[0]
+
+        assert tagging.object == "tagging"
+        assert tagging.oracle_id == "f2b9983e-20d4-4d12-9e2c-ec6d9a345787"
+        assert tagging.illustration_id is None
+        assert tagging.weight == "strong"
+        assert tagging.annotation == "Doom Blade destroys a nonblack creature."
+
+    def test_art_tagging_shape(self):
+        """Art taggings expose illustration_id; oracle_id is None."""
+        tag = scrython.tags.Object(load_fixture("art_tag.json"))
+        tagging = tag.taggings[0]
+
+        assert tagging.illustration_id == "9c1f0a2b-5678-4d12-9e2c-ec6d9a345789"
+        assert tagging.oracle_id is None
+        assert tagging.weight == "median"
+
+    def test_absent_tagging_annotation_returns_none(self):
+        """A tagging without an annotation returns None rather than raising."""
+        tag = scrython.tags.Object(load_fixture("oracle_tag.json"))
+        tagging = tag.taggings[1]
+
+        assert tagging.weight == "very_strong"
+        assert tagging.annotation is None

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -25,27 +25,35 @@ class TestTagObject:
         """Tag accessors return expected scalar values for a bulk tag dict."""
         tag = scrython.tags.Object(load_fixture("oracle_tag.json"))
 
-        assert tag.id == "b7c19924-b4bf-492b-9c98-1e9b0f6e4d3a"
-        assert tag.slug == "removal"
-        assert tag.label == "Removal"
-        assert tag.uri == "https://api.scryfall.com/cards/oracle-tag/removal"
+        assert tag.id == "5bf7154a-2814-4329-a310-4a1343ee3850"
+        assert tag.slug == "bottom-deck-manipulation"
+        assert tag.label == "bottom deck manipulation"
+        assert tag.uri == "https://tagger.scryfall.com/tags/card/bottom-deck-manipulation"
         assert tag.type == "oracle"
-        assert tag.description.startswith("Cards that destroy")
 
-    def test_nullable_list_accessors(self):
-        """Nullable list accessors return their values when present."""
+    def test_hierarchy_accessors(self):
+        """parent_ids, child_ids, and aliases return their values."""
+        tag = scrython.tags.Object(load_fixture("art_tag.json"))
+
+        assert tag.parent_ids == [
+            "504aea75-b144-4530-b014-3e3c7a1fd283",
+            "7b155ecc-bd5e-4757-bde2-c029b6978bad",
+            "b8ad94e6-a042-49ff-bf9e-b963ade6e176",
+            "b88f1b22-c601-4e52-ae99-1fc602c65534",
+        ]
+        assert tag.child_ids == []
+        assert tag.aliases == ["mirri (cat)"]
+        assert tag.description == "Sami's cat."
+
+    def test_null_description_returns_none(self):
+        """A tag whose description is null returns None rather than the literal null."""
         tag = scrython.tags.Object(load_fixture("oracle_tag.json"))
 
-        assert tag.parent_ids == ["a1111111-1111-1111-1111-111111111111"]
-        assert tag.child_ids == [
-            "c2222222-2222-2222-2222-222222222222",
-            "d3333333-3333-3333-3333-333333333333",
-        ]
-        assert tag.aliases == ["interaction", "answers"]
+        assert tag.description is None
 
     def test_absent_nullable_fields_return_none(self):
-        """Nullable fields return None when absent rather than raising."""
-        tag = scrython.tags.Object(load_fixture("art_tag.json"))
+        """Nullable fields return None when the key is absent rather than raising."""
+        tag = scrython.tags.Object({"taggings": []})
 
         assert tag.description is None
         assert tag.parent_ids is None
@@ -62,25 +70,30 @@ class TestTaggings:
 
         assert isinstance(tag.taggings, list)
         assert all(isinstance(t, scrython.tags.Tagging) for t in tag.taggings)
-        assert len(tag.taggings) == 2
+        assert len(tag.taggings) == 4
+
+    def test_taggings_always_a_list_when_absent(self):
+        """taggings is a required field; it returns [] when missing, never None."""
+        tag = scrython.tags.Object({})
+
+        assert tag.taggings == []
 
     def test_oracle_tagging_shape(self):
         """Oracle taggings expose oracle_id; illustration_id is None."""
         tag = scrython.tags.Object(load_fixture("oracle_tag.json"))
         tagging = tag.taggings[0]
 
-        assert tagging.object == "tagging"
-        assert tagging.oracle_id == "f2b9983e-20d4-4d12-9e2c-ec6d9a345787"
+        assert tagging.oracle_id == "97024e8e-dfde-4769-bc27-c3d6fad19e7c"
         assert tagging.illustration_id is None
-        assert tagging.weight == "strong"
-        assert tagging.annotation == "Doom Blade destroys a nonblack creature."
+        assert tagging.weight == "median"
+        assert tagging.annotation.startswith("If you play this with a deck")
 
     def test_art_tagging_shape(self):
         """Art taggings expose illustration_id; oracle_id is None."""
         tag = scrython.tags.Object(load_fixture("art_tag.json"))
         tagging = tag.taggings[0]
 
-        assert tagging.illustration_id == "9c1f0a2b-5678-4d12-9e2c-ec6d9a345789"
+        assert tagging.illustration_id == "d7a21c80-7157-4965-b6d0-d1f6ba0aec33"
         assert tagging.oracle_id is None
         assert tagging.weight == "median"
 
@@ -89,5 +102,5 @@ class TestTaggings:
         tag = scrython.tags.Object(load_fixture("oracle_tag.json"))
         tagging = tag.taggings[1]
 
-        assert tagging.weight == "very_strong"
+        assert tagging.weight == "median"
         assert tagging.annotation is None

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -72,9 +72,9 @@ class TestTaggings:
         assert all(isinstance(t, scrython.tags.Tagging) for t in tag.taggings)
         assert len(tag.taggings) == 4
 
-    def test_taggings_always_a_list_when_absent(self):
-        """taggings is a required field; it returns [] when missing, never None."""
-        tag = scrython.tags.Object({})
+    def test_taggings_empty_array_returns_empty_list(self):
+        """A tag with no direct taggings has a present, empty taggings array."""
+        tag = scrython.tags.Object({"taggings": []})
 
         assert tag.taggings == []
 


### PR DESCRIPTION
# Description
This PR adds a first-class `Tag` object model under `scrython.tags` so callers get typed accessors over the `art_tags` and `oracle_tags` bulk files.

Tags have no dedicated Scryfall endpoint, so I followed the `rulings.Object` wrapper pattern rather than adding a request handler or factory. The flow is: download the bulk file through the existing `bulk_data.ByType(...).download()` path, then wrap each entry in `scrython.tags.Object`. The nested `taggings` array resolves into typed `Tagging` objects through the same `utils.to_object_array` helper that `cards` uses for `all_parts` and `card_faces`. One model covers both shapes (art taggings carry `illustration_id`, oracle taggings carry `oracle_id`); the absent id just returns `None`.

```python
bulk = scrython.bulk_data.ByType(type="oracle_tags")
tags = [scrython.tags.Object(t) for t in bulk.download()]
tags[0].label              # "Removal"
tags[0].taggings[0].weight # "strong"
```

Changes:
- Added the `scrython/tags` module: `Object` (Tag) and `Tagging` wrappers plus `TagObjectMixin` and `TaggingObjectMixin` accessors over `_scryfall_data`.
- Resolved `tag.taggings` into `list[Tagging]` via `utils.to_object_array`, with nullable accessors returning `None` when absent.
- Added `ScryfallTagData` and `ScryfallTaggingData` to `types.py`.
- Registered `tags` in the package `__init__` imports and `__all__`.
- Documented `art_tags` / `oracle_tags` and a download-then-wrap example in the `bulk_data.ByType` docstring.
- Added `tests/test_tags.py` with `Removal` (oracle) and `Squirrel` (art) fixtures covering both shapes, the taggings list, and every nullable.

## Testing
- [x] `python -m pytest` (448 passed, 1 skipped)
- [x] `ruff check` / `black --check` clean on the new code
- [x] `mypy scrython/tags` clean

The one unrelated failure (`test_packaging::test_py_typed_in_wheel`) is a local env gap (`No module named build`); it fails identically on a clean tree.

Closes #224
