### PR TITLE
bulk_data accessors and download() are broken by Scryfall's bulk-data shape change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **`BulkDataObjectMixin.download()`**: Now targets `jsonl_download_uri` and parses the response as newline-delimited JSON (JSONL) rather than a single JSON array.
+- **`BulkDataObjectMixin.download()`**: Always decompresses the response instead of decompressing only when the CDN sends `Content-Encoding: gzip`. Scryfall documents `jsonl_download_uri` as hosting the file as `.jsonl.gz`, and `data.scryfall.io` serves it as `content-type: application/gzip` with no `Content-Encoding` header, so the previous header check never fired against a live response. The previous `Accept-Encoding: gzip, identity` request header is also gone; urllib's `identity` default is what this method wants.
+- **`BulkDataObjectMixin.download()`**: `chunk_size` now applies only when `progress=True`; the non-progress path streams decompression directly off the response.
 - **`ScryfallBulkDataData`**: TypedDict updated to match the current Scryfall bulk-data shape — `download_uri`, `size`, `content_type`, and `content_encoding` removed; `jsonl_download_uri` and `compressed_size` added.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+- **`BulkDataObjectMixin.jsonl_download_uri`**: New accessor for the gzip-compressed JSONL download URI, replacing the removed `download_uri` field.
+- **`BulkDataObjectMixin.compressed_size`**: New accessor for the compressed file size in bytes, replacing the removed `size` field.
+
+### Changed
+- **`BulkDataObjectMixin.download()`**: Now targets `jsonl_download_uri` and parses the response as newline-delimited JSON (JSONL) rather than a single JSON array.
+- **`ScryfallBulkDataData`**: TypedDict updated to match the current Scryfall bulk-data shape — `download_uri`, `size`, `content_type`, and `content_encoding` removed; `jsonl_download_uri` and `compressed_size` added.
+
+### Removed
+- **`BulkDataObjectMixin.download_uri`**: Removed; Scryfall no longer returns this field. Use `jsonl_download_uri` instead.
+- **`BulkDataObjectMixin.size`**: Removed; Scryfall no longer returns this field. Use `compressed_size` instead.
+- **`BulkDataObjectMixin.content_type`**: Removed; Scryfall no longer returns this field.
+- **`BulkDataObjectMixin.content_encoding`**: Removed; Scryfall no longer returns this field.
+
+---
+
 ## [2.2.0] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ all_bulk = scrython.bulk_data.All()
 
 for bulk in all_bulk.data:
     print(f"{bulk.name}: {bulk.description}")
-    print(f"Size: {bulk.size / 1_000_000:.1f} MB")
+    print(f"Compressed size: {bulk.compressed_size / 1_000_000:.1f} MB")
 
 # Download oracle cards (all unique cards with Oracle text)
 oracle_cards = scrython.bulk_data.ByType(type='oracle_cards')

--- a/scrython/bulk_data/bulk_data.py
+++ b/scrython/bulk_data/bulk_data.py
@@ -32,8 +32,8 @@ class All(ScryfallListMixin, ScrythonRequestHandler[ScryfallListData]):
         # List available files
         for bulk in all_bulk.data:
             print(f"{bulk.name}: {bulk.description}")
-            print(f"Size: {bulk.size / 1_000_000:.1f} MB")
-            print(f"Download: {bulk.download_uri}")
+            print(f"Compressed size: {bulk.compressed_size / 1_000_000:.1f} MB")
+            print(f"Download: {bulk.jsonl_download_uri}")
             print()
 
     See: https://scryfall.com/docs/api/bulk-data
@@ -59,7 +59,7 @@ class ById(BulkDataObjectMixin, ScrythonRequestHandler[ScryfallBulkDataData]):
         bulk = scrython.bulk_data.ById(id='uuid-here')
         print(f"File: {bulk.name}")
         print(f"Last updated: {bulk.updated_at}")
-        print(f"Download from: {bulk.download_uri}")
+        print(f"Download from: {bulk.jsonl_download_uri}")
 
     See: https://scryfall.com/docs/api/bulk-data/id
     """
@@ -86,13 +86,11 @@ class ByType(BulkDataObjectMixin, ScrythonRequestHandler[ScryfallBulkDataData]):
         # Get Oracle Cards bulk data
         oracle = scrython.bulk_data.ByType(type='oracle_cards')
         print(f"Oracle Cards file: {oracle.name}")
-        print(f"Size: {oracle.size / 1_000_000:.1f} MB")
+        print(f"Compressed size: {oracle.compressed_size / 1_000_000:.1f} MB")
         print(f"Updated: {oracle.updated_at}")
 
         # Download the file
-        import requests
-        response = requests.get(oracle.download_uri)
-        cards = response.json()
+        cards = oracle.download()
         print(f"Downloaded {len(cards)} cards")
 
         # Download a tag bulk file and wrap each entry in a typed Tag object

--- a/scrython/bulk_data/bulk_data_mixins.py
+++ b/scrython/bulk_data/bulk_data_mixins.py
@@ -1,4 +1,5 @@
 import gzip
+import io
 import json
 from typing import Any
 from urllib.request import Request, urlopen
@@ -103,11 +104,9 @@ class BulkDataObjectMixin:
         """
         Download and parse the bulk JSONL file from Scryfall.
 
-        The bulk data file is a gzip-compressed JSONL (newline-delimited JSON) file
-        downloaded from Scryfall's CDN. The method automatically detects if the
-        response is gzip-compressed by checking HTTP Content-Encoding headers and
-        handles decompression accordingly. Each line is parsed as a separate JSON
-        object and returned as a list.
+        Scryfall documents jsonl_download_uri as hosting this bulk file as
+        .jsonl.gz, so the response body is always a gzip file. It is decompressed
+        and parsed one line at a time, and each line is a separate JSON object.
 
         Args:
             filepath: Optional path to save the parsed data as a JSON file.
@@ -115,7 +114,8 @@ class BulkDataObjectMixin:
             return_data: If True, return parsed data. If False and
                         filepath is provided, only saves file without returning data.
                         Default: True.
-            chunk_size: Download chunk size in bytes. Default: 8192.
+            chunk_size: Read size in bytes for the progress bar. Ignored when
+                       progress is False. Default: 8192.
             progress: If True, display a progress bar during download (requires tqdm).
                      Default: False.
 
@@ -142,13 +142,6 @@ class BulkDataObjectMixin:
             Bulk data files can be very large (100+ MB compressed, 500+ MB uncompressed).
             Be mindful of memory usage when loading entire files into memory.
         """
-        download_url = self.jsonl_download_uri
-
-        request = Request(download_url)
-        request.add_header("User-Agent", ScrythonRequestHandler._user_agent)
-        request.add_header("Accept-Encoding", "gzip, identity")
-
-        # Optional progress bar
         if progress:
             try:
                 from tqdm.auto import tqdm
@@ -158,15 +151,14 @@ class BulkDataObjectMixin:
                     "Install with: pip install scrython[progress] or pip install tqdm"
                 ) from exc
 
-            # Download with progress bar
-            with urlopen(request) as response:
-                # Check actual HTTP Content-Encoding header
-                content_encoding = response.info().get("Content-Encoding", "").lower()
+        request = Request(self.jsonl_download_uri)
+        request.add_header("User-Agent", ScrythonRequestHandler._user_agent)
 
-                total_size = int(response.headers.get("Content-Length", 0))
-                pbar = tqdm(total=total_size, unit="B", unit_scale=True, desc="Downloading")
-
-                # Read in chunks
+        with urlopen(request) as response:
+            if progress:
+                pbar = tqdm(
+                    total=self.compressed_size, unit="B", unit_scale=True, desc="Downloading"
+                )
                 chunks = []
                 while True:
                     chunk = response.read(chunk_size)
@@ -175,41 +167,18 @@ class BulkDataObjectMixin:
                     chunks.append(chunk)
                     pbar.update(len(chunk))
                 pbar.close()
-
-                downloaded_data = b"".join(chunks)
-
-            # Conditionally decompress based on HTTP header
-            if content_encoding == "gzip":
-                with tqdm(
-                    total=len(downloaded_data), unit="B", unit_scale=True, desc="Decompressing"
-                ):
-                    data = gzip.decompress(downloaded_data)
+                compressed_stream: Any = io.BytesIO(b"".join(chunks))
             else:
-                # Already decompressed or plain JSONL
-                data = downloaded_data
-        else:
-            # Download without progress bar
-            with urlopen(request) as response:
-                # Check actual HTTP Content-Encoding header
-                content_encoding = response.info().get("Content-Encoding", "").lower()
+                compressed_stream = response
 
-                if content_encoding == "gzip":
-                    # Decompress with streaming
-                    with gzip.GzipFile(fileobj=response) as gz_file:
-                        data = gz_file.read()
-                else:
-                    # Read plain JSONL
-                    data = response.read()
+            # Parse JSONL: each non-empty line is a separate JSON object.
+            with gzip.GzipFile(fileobj=compressed_stream) as jsonl_stream:
+                parsed_data: list[dict[str, Any]] = [
+                    json.loads(line) for line in jsonl_stream if line.strip()
+                ]
 
-        # Parse JSONL: each non-empty line is a separate JSON object.
-        parsed_data: list[dict[str, Any]] = [
-            json.loads(line) for line in data.decode("utf-8").splitlines() if line.strip()
-        ]
-
-        # Save to file if requested
         if filepath:
             with open(filepath, "w", encoding="utf-8") as f:
                 json.dump(parsed_data, f, indent=2)
 
-        # Return data if requested
         return parsed_data if return_data else None

--- a/scrython/bulk_data/bulk_data_mixins.py
+++ b/scrython/bulk_data/bulk_data_mixins.py
@@ -65,16 +65,22 @@ class BulkDataObjectMixin:
         return self._scryfall_data["description"]
 
     @property
-    def download_uri(self) -> str:
+    def jsonl_download_uri(self) -> str:
         """
-        The URI that hosts this bulk file for fetching.
+        The URI to download this bulk file in gzip-compressed JSONL format.
 
         Type: URI (Required)
-
-        Note: Files may be compressed with gzip depending on CDN/proxy configuration.
-        The download() method automatically detects encoding from HTTP headers.
         """
-        return self._scryfall_data["download_uri"]
+        return self._scryfall_data["jsonl_download_uri"]
+
+    @property
+    def compressed_size(self) -> int:
+        """
+        The size of the compressed file in integer bytes.
+
+        Type: Integer (Required)
+        """
+        return self._scryfall_data["compressed_size"]
 
     @property
     def updated_at(self) -> str:
@@ -87,33 +93,6 @@ class BulkDataObjectMixin:
         """
         return self._scryfall_data["updated_at"]
 
-    @property
-    def size(self) -> int:
-        """
-        The size of this file in integer bytes.
-
-        Type: Integer (Required)
-        """
-        return self._scryfall_data["size"]
-
-    @property
-    def content_type(self) -> str:
-        """
-        The MIME type of this file.
-
-        Type: String (Required)
-        """
-        return self._scryfall_data["content_type"]
-
-    @property
-    def content_encoding(self) -> str:
-        """
-        The Content-Encoding encoding that will be used to transmit this file when you download it.
-
-        Type: String (Required)
-        """
-        return self._scryfall_data["content_encoding"]
-
     def download(
         self,
         filepath: str | None = None,
@@ -122,17 +101,18 @@ class BulkDataObjectMixin:
         progress: bool = False,
     ) -> list[dict[str, Any]] | None:
         """
-        Download and parse bulk data file from Scryfall.
+        Download and parse the bulk JSONL file from Scryfall.
 
-        The bulk data file is downloaded from Scryfall's CDN. The method automatically
-        detects if the response is gzip-compressed by checking HTTP Content-Encoding
-        headers and handles decompression accordingly. The JSON data is then parsed
-        and optionally saved to a file.
+        The bulk data file is a gzip-compressed JSONL (newline-delimited JSON) file
+        downloaded from Scryfall's CDN. The method automatically detects if the
+        response is gzip-compressed by checking HTTP Content-Encoding headers and
+        handles decompression accordingly. Each line is parsed as a separate JSON
+        object and returned as a list.
 
         Args:
-            filepath: Optional path to save the decompressed JSON file.
+            filepath: Optional path to save the parsed data as a JSON file.
                      If None, file is not saved to disk.
-            return_data: If True, return parsed JSON data. If False and
+            return_data: If True, return parsed data. If False and
                         filepath is provided, only saves file without returning data.
                         Default: True.
             chunk_size: Download chunk size in bytes. Default: 8192.
@@ -162,7 +142,7 @@ class BulkDataObjectMixin:
             Bulk data files can be very large (100+ MB compressed, 500+ MB uncompressed).
             Be mindful of memory usage when loading entire files into memory.
         """
-        download_url = self.download_uri
+        download_url = self.jsonl_download_uri
 
         request = Request(download_url)
         request.add_header("User-Agent", ScrythonRequestHandler._user_agent)
@@ -205,7 +185,7 @@ class BulkDataObjectMixin:
                 ):
                     data = gzip.decompress(downloaded_data)
             else:
-                # Already decompressed or plain JSON
+                # Already decompressed or plain JSONL
                 data = downloaded_data
         else:
             # Download without progress bar
@@ -218,11 +198,13 @@ class BulkDataObjectMixin:
                     with gzip.GzipFile(fileobj=response) as gz_file:
                         data = gz_file.read()
                 else:
-                    # Read plain JSON
+                    # Read plain JSONL
                     data = response.read()
 
-        # Parse JSON. The annotation narrows json.loads's Any return; no cast needed.
-        parsed_data: list[dict[str, Any]] = json.loads(data.decode("utf-8"))
+        # Parse JSONL: each non-empty line is a separate JSON object.
+        parsed_data: list[dict[str, Any]] = [
+            json.loads(line) for line in data.decode("utf-8").splitlines() if line.strip()
+        ]
 
         # Save to file if requested
         if filepath:

--- a/scrython/types.py
+++ b/scrython/types.py
@@ -285,10 +285,8 @@ class ScryfallBulkDataData(TypedDict):
     uri: URI
     name: str
     description: str
-    download_uri: URI
-    size: int
-    content_type: str
-    content_encoding: str
+    jsonl_download_uri: URI
+    compressed_size: int
 
 
 class ScryfallListData(TypedDict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,9 +223,9 @@ def sample_bulk_data():
         "type": "oracle_cards",
         "name": "Oracle Cards",
         "description": "All cards, each uniquely identified by Oracle ID",
-        "download_uri": "https://api.scryfall.com/bulk-data/27bf3214-1271-490b-bdfe-c0be6c23d02e/download",
-        "updated_at": "2025-01-01T12:00:00.000Z",
-        "size": 123456789,
+        "jsonl_download_uri": "https://data.scryfall.io/oracle-cards/oracle-cards-20260811090155.jsonl.gz",
+        "updated_at": "2026-08-11T09:01:55.863+00:00",
+        "compressed_size": 24502785,
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,9 +223,9 @@ def sample_bulk_data():
         "type": "oracle_cards",
         "name": "Oracle Cards",
         "description": "All cards, each uniquely identified by Oracle ID",
-        "jsonl_download_uri": "https://data.scryfall.io/oracle-cards/oracle-cards-20260811090155.jsonl.gz",
-        "updated_at": "2026-08-11T09:01:55.863+00:00",
-        "compressed_size": 24502785,
+        "jsonl_download_uri": "https://data.scryfall.io/oracle-cards/oracle-cards-20260820090157.jsonl.gz",
+        "updated_at": "2026-08-20T09:01:57.484+00:00",
+        "compressed_size": 24530127,
     }
 
 

--- a/tests/fixtures/bulk_data/all.json
+++ b/tests/fixtures/bulk_data/all.json
@@ -8,21 +8,21 @@
       "type": "oracle_cards",
       "name": "Oracle Cards",
       "description": "A JSON file containing one Scryfall card object for each Oracle ID on Scryfall.",
-      "updated_at": "2026-08-11T09:01:55.863+00:00",
+      "updated_at": "2026-08-20T09:01:57.484+00:00",
       "uri": "https://api.scryfall.com/bulk-data/27bf3214-1271-490b-bdfe-c0be6c23d02e",
-      "jsonl_download_uri": "https://data.scryfall.io/oracle-cards/oracle-cards-20260811090155.jsonl.gz",
-      "compressed_size": 24502785
+      "jsonl_download_uri": "https://data.scryfall.io/oracle-cards/oracle-cards-20260820090157.jsonl.gz",
+      "compressed_size": 24530127
     },
     {
       "object": "bulk_data",
-      "id": "922288cb-4bef-45e1-bb30-0c2bd3d3534e",
+      "id": "6bbcf976-6369-4401-88fc-3a9e4984c305",
       "type": "unique_artwork",
       "name": "Unique Artwork",
       "description": "A JSON file of Scryfall card objects that together contain all unique artworks.",
-      "updated_at": "2026-08-11T09:01:55.863+00:00",
-      "uri": "https://api.scryfall.com/bulk-data/922288cb-4bef-45e1-bb30-0c2bd3d3534e",
-      "jsonl_download_uri": "https://data.scryfall.io/unique-artwork/unique-artwork-20260811090155.jsonl.gz",
-      "compressed_size": 38912400
+      "updated_at": "2026-08-20T09:02:29.407+00:00",
+      "uri": "https://api.scryfall.com/bulk-data/6bbcf976-6369-4401-88fc-3a9e4984c305",
+      "jsonl_download_uri": "https://data.scryfall.io/unique-artwork/unique-artwork-20260820090229.jsonl.gz",
+      "compressed_size": 37421943
     }
   ]
 }

--- a/tests/fixtures/bulk_data/all.json
+++ b/tests/fixtures/bulk_data/all.json
@@ -8,11 +8,10 @@
       "type": "oracle_cards",
       "name": "Oracle Cards",
       "description": "A JSON file containing one Scryfall card object for each Oracle ID on Scryfall.",
-      "download_uri": "https://api.scryfall.com/bulk-data/27bf3214-1271-490b-bdfe-c0be6c23d02e/download",
-      "updated_at": "2025-01-01T12:00:00.000Z",
-      "size": 123456789,
-      "content_type": "application/json",
-      "content_encoding": "gzip"
+      "updated_at": "2026-08-11T09:01:55.863+00:00",
+      "uri": "https://api.scryfall.com/bulk-data/27bf3214-1271-490b-bdfe-c0be6c23d02e",
+      "jsonl_download_uri": "https://data.scryfall.io/oracle-cards/oracle-cards-20260811090155.jsonl.gz",
+      "compressed_size": 24502785
     },
     {
       "object": "bulk_data",
@@ -20,11 +19,10 @@
       "type": "unique_artwork",
       "name": "Unique Artwork",
       "description": "A JSON file of Scryfall card objects that together contain all unique artworks.",
-      "download_uri": "https://api.scryfall.com/bulk-data/922288cb-4bef-45e1-bb30-0c2bd3d3534e/download",
-      "updated_at": "2025-01-01T12:00:00.000Z",
-      "size": 234567890,
-      "content_type": "application/json",
-      "content_encoding": "gzip"
+      "updated_at": "2026-08-11T09:01:55.863+00:00",
+      "uri": "https://api.scryfall.com/bulk-data/922288cb-4bef-45e1-bb30-0c2bd3d3534e",
+      "jsonl_download_uri": "https://data.scryfall.io/unique-artwork/unique-artwork-20260811090155.jsonl.gz",
+      "compressed_size": 38912400
     }
   ]
 }

--- a/tests/fixtures/bulk_data/by_id.json
+++ b/tests/fixtures/bulk_data/by_id.json
@@ -5,7 +5,7 @@
   "type": "oracle_cards",
   "name": "Oracle Cards",
   "description": "A JSON file containing one Scryfall card object for each Oracle ID on Scryfall.",
-  "updated_at": "2026-08-11T09:01:55.863+00:00",
-  "jsonl_download_uri": "https://data.scryfall.io/oracle-cards/oracle-cards-20260811090155.jsonl.gz",
-  "compressed_size": 24502785
+  "updated_at": "2026-08-20T09:01:57.484+00:00",
+  "jsonl_download_uri": "https://data.scryfall.io/oracle-cards/oracle-cards-20260820090157.jsonl.gz",
+  "compressed_size": 24530127
 }

--- a/tests/fixtures/bulk_data/by_id.json
+++ b/tests/fixtures/bulk_data/by_id.json
@@ -5,9 +5,7 @@
   "type": "oracle_cards",
   "name": "Oracle Cards",
   "description": "A JSON file containing one Scryfall card object for each Oracle ID on Scryfall.",
-  "download_uri": "https://api.scryfall.com/bulk-data/27bf3214-1271-490b-bdfe-c0be6c23d02e/download",
-  "updated_at": "2025-01-01T12:00:00.000Z",
-  "size": 123456789,
-  "content_type": "application/json",
-  "content_encoding": "gzip"
+  "updated_at": "2026-08-11T09:01:55.863+00:00",
+  "jsonl_download_uri": "https://data.scryfall.io/oracle-cards/oracle-cards-20260811090155.jsonl.gz",
+  "compressed_size": 24502785
 }

--- a/tests/test_bulk_data.py
+++ b/tests/test_bulk_data.py
@@ -96,11 +96,11 @@ class TestBulkDataMixins:
         assert bulk.type == "oracle_cards"
         assert bulk.name == "Oracle Cards"
         assert (
-            bulk.download_uri
-            == "https://api.scryfall.com/bulk-data/27bf3214-1271-490b-bdfe-c0be6c23d02e/download"
+            bulk.jsonl_download_uri
+            == "https://data.scryfall.io/oracle-cards/oracle-cards-20260811090155.jsonl.gz"
         )
-        assert bulk.updated_at == "2025-01-01T12:00:00.000Z"
-        assert bulk.size == 123456789
+        assert bulk.updated_at == "2026-08-11T09:01:55.863+00:00"
+        assert bulk.compressed_size == 24502785
 
     def test_bulk_data_object_from_list(self, mock_urlopen):
         """Test that BulkDataObject wrapper works correctly."""
@@ -122,9 +122,10 @@ class TestBulkDataDownload:
         mock_urlopen.set_response("bulk_data/by_id.json")
         bulk = ByType(type="oracle_cards")
 
-        # Mock the download URL response
+        # Mock the download URL response with JSONL format
         test_data = [{"id": "card1", "name": "Test Card"}]
-        compressed_data = gzip.compress(json.dumps(test_data).encode("utf-8"))
+        jsonl_data = "\n".join(json.dumps(obj) for obj in test_data).encode("utf-8")
+        compressed_data = gzip.compress(jsonl_data)
 
         with patch("scrython.bulk_data.bulk_data_mixins.urlopen") as mock_download:
             # Wrap compressed data in BytesIO for proper file-like behavior
@@ -147,7 +148,8 @@ class TestBulkDataDownload:
         bulk = ByType(type="oracle_cards")
 
         test_data = [{"id": "card1", "name": "Test Card"}]
-        compressed_data = gzip.compress(json.dumps(test_data).encode("utf-8"))
+        jsonl_data = "\n".join(json.dumps(obj) for obj in test_data).encode("utf-8")
+        compressed_data = gzip.compress(jsonl_data)
 
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as tmp:
             tmp_path = tmp.name
@@ -182,7 +184,8 @@ class TestBulkDataDownload:
         bulk = ByType(type="oracle_cards")
 
         test_data = [{"id": "card1", "name": "Test Card"}]
-        compressed_data = gzip.compress(json.dumps(test_data).encode("utf-8"))
+        jsonl_data = "\n".join(json.dumps(obj) for obj in test_data).encode("utf-8")
+        compressed_data = gzip.compress(jsonl_data)
 
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as tmp:
             tmp_path = tmp.name
@@ -259,18 +262,18 @@ class TestBulkDataDownload:
             bulk.download(progress=True)
 
     def test_download_uncompressed_no_progress(self, mock_urlopen):
-        """Test download handles uncompressed JSON without progress bar."""
+        """Test download handles uncompressed JSONL without progress bar."""
         mock_urlopen.set_response("bulk_data/by_id.json")
         bulk = ByType(type="oracle_cards")
 
-        # Test with plain JSON (not gzip compressed)
+        # Test with plain JSONL (not gzip compressed)
         test_data = [{"id": "card1", "name": "Test Card"}]
-        plain_json = json.dumps(test_data).encode("utf-8")
+        plain_jsonl = "\n".join(json.dumps(obj) for obj in test_data).encode("utf-8")
 
         with patch("scrython.bulk_data.bulk_data_mixins.urlopen") as mock_download:
             # Create mock with NO Content-Encoding header (empty string)
             mock_response = MagicMock()
-            mock_response.read.return_value = plain_json
+            mock_response.read.return_value = plain_jsonl
             mock_response.info.return_value.get.return_value = ""  # No encoding header
             mock_response.__enter__.return_value = mock_response
             mock_response.__exit__.return_value = None
@@ -283,25 +286,25 @@ class TestBulkDataDownload:
             assert result[0]["name"] == "Test Card"
 
     def test_download_uncompressed_with_progress(self, mock_urlopen):
-        """Test download handles uncompressed JSON with progress bar."""
+        """Test download handles uncompressed JSONL with progress bar."""
         # Skip if tqdm is not installed
         pytest.importorskip("tqdm")
 
         mock_urlopen.set_response("bulk_data/by_id.json")
         bulk = ByType(type="oracle_cards")
 
-        # Test with plain JSON (not gzip compressed)
+        # Test with plain JSONL (not gzip compressed)
         test_data = [{"id": "card1", "name": "Test Card"}]
-        plain_json = json.dumps(test_data).encode("utf-8")
+        plain_jsonl = "\n".join(json.dumps(obj) for obj in test_data).encode("utf-8")
 
         with patch("scrython.bulk_data.bulk_data_mixins.urlopen") as mock_download:
             # Create mock with NO Content-Encoding header
             mock_response = MagicMock()
             mock_response.read.side_effect = [
-                plain_json,
+                plain_jsonl,
                 b"",
             ]  # Return data then empty to signal EOF
-            mock_response.headers.get.return_value = str(len(plain_json))
+            mock_response.headers.get.return_value = str(len(plain_jsonl))
             mock_response.info.return_value.get.return_value = ""  # No encoding header
             mock_response.__enter__.return_value = mock_response
             mock_response.__exit__.return_value = None
@@ -325,7 +328,7 @@ class TestBulkDataDownload:
         with patch("scrython.bulk_data.bulk_data_mixins.urlopen") as mock_download:
             # Set up mock to allow inspection of the Request object
             mock_response = MagicMock()
-            mock_response.read.return_value = b"[]"
+            mock_response.read.return_value = b""
             mock_response.info.return_value.get.return_value = ""
             mock_response.__enter__.return_value = mock_response
             mock_response.__exit__.return_value = None

--- a/tests/test_bulk_data.py
+++ b/tests/test_bulk_data.py
@@ -97,10 +97,10 @@ class TestBulkDataMixins:
         assert bulk.name == "Oracle Cards"
         assert (
             bulk.jsonl_download_uri
-            == "https://data.scryfall.io/oracle-cards/oracle-cards-20260811090155.jsonl.gz"
+            == "https://data.scryfall.io/oracle-cards/oracle-cards-20260820090157.jsonl.gz"
         )
-        assert bulk.updated_at == "2026-08-11T09:01:55.863+00:00"
-        assert bulk.compressed_size == 24502785
+        assert bulk.updated_at == "2026-08-20T09:01:57.484+00:00"
+        assert bulk.compressed_size == 24530127
 
     def test_bulk_data_object_from_list(self, mock_urlopen):
         """Test that BulkDataObject wrapper works correctly."""
@@ -255,56 +255,55 @@ class TestBulkDataDownload:
         bulk = ByType(type="oracle_cards")
 
         with (
-            patch("scrython.bulk_data.bulk_data_mixins.urlopen"),
+            patch("scrython.bulk_data.bulk_data_mixins.urlopen") as mock_bulk_urlopen,
             patch.dict("sys.modules", {"tqdm": None}),
             pytest.raises(ImportError, match="tqdm is required"),
         ):
             bulk.download(progress=True)
 
-    def test_download_uncompressed_no_progress(self, mock_urlopen):
-        """Test download handles uncompressed JSONL without progress bar."""
+        mock_bulk_urlopen.assert_not_called()
+
+    def test_download_without_content_encoding_header_no_progress(self, mock_urlopen):
+        """Test download decompresses when the CDN sends no Content-Encoding header.
+
+        data.scryfall.io serves the .jsonl.gz file as content-type application/gzip
+        and sends no Content-Encoding header, because the gzip is the file format
+        rather than a transport encoding.
+        """
         mock_urlopen.set_response("bulk_data/by_id.json")
         bulk = ByType(type="oracle_cards")
 
-        # Test with plain JSONL (not gzip compressed)
-        test_data = [{"id": "card1", "name": "Test Card"}]
-        plain_jsonl = "\n".join(json.dumps(obj) for obj in test_data).encode("utf-8")
+        test_data = [{"id": "jace", "name": "Jace, the Mind Sculptor"}]
+        jsonl_data = "\n".join(json.dumps(obj) for obj in test_data).encode("utf-8")
+        compressed_data = gzip.compress(jsonl_data)
 
         with patch("scrython.bulk_data.bulk_data_mixins.urlopen") as mock_download:
-            # Create mock with NO Content-Encoding header (empty string)
-            mock_response = MagicMock()
-            mock_response.read.return_value = plain_jsonl
-            mock_response.info.return_value.get.return_value = ""  # No encoding header
-            mock_response.__enter__.return_value = mock_response
-            mock_response.__exit__.return_value = None
-            mock_download.return_value = mock_response
+            mock_response = BytesIO(compressed_data)
+            mock_response.info = MagicMock(return_value=MagicMock(get=MagicMock(return_value="")))
+            mock_download.return_value.__enter__.return_value = mock_response
 
             result = bulk.download()
 
             assert result == test_data
-            assert len(result) == 1
-            assert result[0]["name"] == "Test Card"
 
-    def test_download_uncompressed_with_progress(self, mock_urlopen):
-        """Test download handles uncompressed JSONL with progress bar."""
+    def test_download_without_content_encoding_header_with_progress(self, mock_urlopen):
+        """Test the progress path decompresses when no Content-Encoding header is sent."""
         # Skip if tqdm is not installed
         pytest.importorskip("tqdm")
 
         mock_urlopen.set_response("bulk_data/by_id.json")
         bulk = ByType(type="oracle_cards")
 
-        # Test with plain JSONL (not gzip compressed)
-        test_data = [{"id": "card1", "name": "Test Card"}]
-        plain_jsonl = "\n".join(json.dumps(obj) for obj in test_data).encode("utf-8")
+        test_data = [{"id": "liliana", "name": "Liliana of the Veil"}]
+        jsonl_data = "\n".join(json.dumps(obj) for obj in test_data).encode("utf-8")
+        compressed_data = gzip.compress(jsonl_data)
 
         with patch("scrython.bulk_data.bulk_data_mixins.urlopen") as mock_download:
-            # Create mock with NO Content-Encoding header
             mock_response = MagicMock()
             mock_response.read.side_effect = [
-                plain_jsonl,
+                compressed_data,
                 b"",
             ]  # Return data then empty to signal EOF
-            mock_response.headers.get.return_value = str(len(plain_jsonl))
             mock_response.info.return_value.get.return_value = ""  # No encoding header
             mock_response.__enter__.return_value = mock_response
             mock_response.__exit__.return_value = None
@@ -313,11 +312,8 @@ class TestBulkDataDownload:
             result = bulk.download(progress=True)
 
             assert result == test_data
-            assert len(result) == 1
-            assert result[0]["name"] == "Test Card"
 
-    def test_download_sets_headers(self, mock_urlopen):
-        """Test download sets proper User-Agent and Accept-Encoding headers."""
+    def test_download_sets_user_agent(self, mock_urlopen):
         from urllib.request import Request
 
         from scrython.base import ScrythonRequestHandler
@@ -327,12 +323,9 @@ class TestBulkDataDownload:
 
         with patch("scrython.bulk_data.bulk_data_mixins.urlopen") as mock_download:
             # Set up mock to allow inspection of the Request object
-            mock_response = MagicMock()
-            mock_response.read.return_value = b""
-            mock_response.info.return_value.get.return_value = ""
-            mock_response.__enter__.return_value = mock_response
-            mock_response.__exit__.return_value = None
-            mock_download.return_value = mock_response
+            mock_response = BytesIO(gzip.compress(b""))
+            mock_response.info = MagicMock(return_value=MagicMock(get=MagicMock(return_value="")))
+            mock_download.return_value.__enter__.return_value = mock_response
 
             bulk.download()
 
@@ -343,4 +336,3 @@ class TestBulkDataDownload:
 
             # Verify headers are set correctly
             assert request.get_header("User-agent") == ScrythonRequestHandler._user_agent
-            assert request.get_header("Accept-encoding") == "gzip, identity"

--- a/tests/test_property_types.py
+++ b/tests/test_property_types.py
@@ -226,11 +226,9 @@ BULK_DATA_OBJECT_PROPERTIES = [
     ("type", str, False, "Bulk data type"),
     ("name", str, False, "Bulk data name"),
     ("description", str, False, "Description"),
-    ("download_uri", str, False, "Download URI"),
+    ("jsonl_download_uri", str, False, "JSONL download URI"),
     ("updated_at", str, False, "Last updated timestamp"),
-    ("size", int, False, "File size in bytes"),
-    ("content_type", str, False, "MIME type"),
-    ("content_encoding", str, False, "Content encoding"),
+    ("compressed_size", int, False, "Compressed file size in bytes"),
 ]
 
 

--- a/tests/usage/fixtures/bulk_data_by_id__oracle_cards.json
+++ b/tests/usage/fixtures/bulk_data_by_id__oracle_cards.json
@@ -1,6 +1,6 @@
 {
   "_provenance": {
-    "captured_at": "2026-05-30T23:30:47.712824+00:00",
+    "captured_at": "2026-08-11T09:01:55.863+00:00",
     "endpoint": "bulk-data/id",
     "source_url": "https://api.scryfall.com/bulk-data/27bf3214-1271-490b-bdfe-c0be6c23d02e",
     "scryfall_id": "27bf3214-1271-490b-bdfe-c0be6c23d02e"
@@ -9,13 +9,11 @@
     "object": "bulk_data",
     "id": "27bf3214-1271-490b-bdfe-c0be6c23d02e",
     "type": "oracle_cards",
-    "updated_at": "2026-05-30T21:07:31.013+00:00",
+    "updated_at": "2026-08-11T09:01:55.863+00:00",
     "uri": "https://api.scryfall.com/bulk-data/27bf3214-1271-490b-bdfe-c0be6c23d02e",
     "name": "Oracle Cards",
     "description": "A JSON file containing one Scryfall card object for each Oracle ID on Scryfall. The chosen sets for the cards are an attempt to return the most up-to-date recognizable version of the card.",
-    "size": 173115837,
-    "download_uri": "https://data.scryfall.io/oracle-cards/oracle-cards-20260530210731.json",
-    "content_type": "application/json",
-    "content_encoding": "gzip"
+    "jsonl_download_uri": "https://data.scryfall.io/oracle-cards/oracle-cards-20260811090155.jsonl.gz",
+    "compressed_size": 24502785
   }
 }

--- a/tests/usage/fixtures/bulk_data_by_id__oracle_cards.json
+++ b/tests/usage/fixtures/bulk_data_by_id__oracle_cards.json
@@ -1,6 +1,6 @@
 {
   "_provenance": {
-    "captured_at": "2026-08-11T09:01:55.863+00:00",
+    "captured_at": "2026-08-20T17:49:37.290850+00:00",
     "endpoint": "bulk-data/id",
     "source_url": "https://api.scryfall.com/bulk-data/27bf3214-1271-490b-bdfe-c0be6c23d02e",
     "scryfall_id": "27bf3214-1271-490b-bdfe-c0be6c23d02e"
@@ -9,11 +9,11 @@
     "object": "bulk_data",
     "id": "27bf3214-1271-490b-bdfe-c0be6c23d02e",
     "type": "oracle_cards",
-    "updated_at": "2026-08-11T09:01:55.863+00:00",
+    "updated_at": "2026-08-20T09:01:57.484+00:00",
     "uri": "https://api.scryfall.com/bulk-data/27bf3214-1271-490b-bdfe-c0be6c23d02e",
     "name": "Oracle Cards",
     "description": "A JSON file containing one Scryfall card object for each Oracle ID on Scryfall. The chosen sets for the cards are an attempt to return the most up-to-date recognizable version of the card.",
-    "jsonl_download_uri": "https://data.scryfall.io/oracle-cards/oracle-cards-20260811090155.jsonl.gz",
-    "compressed_size": 24502785
+    "jsonl_download_uri": "https://data.scryfall.io/oracle-cards/oracle-cards-20260820090157.jsonl.gz",
+    "compressed_size": 24530127
   }
 }


### PR DESCRIPTION
Closes #238

Opened by Sandcastle. 1 commit(s) on `sandcastle/issue-238`.