### PR TITLE
Property sweep: card_face and related_card specs with hard-fail coverage

### DIFF
--- a/tests/sweep/test_property_sweep.py
+++ b/tests/sweep/test_property_sweep.py
@@ -17,6 +17,7 @@ import pytest
 from scrython.base_mixins import ScryfallCatalogMixin, ScryfallListMixin
 from scrython.bulk_data import Object as BulkDataObject
 from scrython.cards import Object
+from scrython.cards.cards_mixins import CardFaceMixin, RelatedCardsObjectMixin
 from scrython.sets import Object as SetsObject
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -80,6 +81,20 @@ class _WrappedList(_BareList):
 
 class _BareCatalog(ScryfallCatalogMixin):
     """Instantiable from a dict."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._scryfall_data = data  # type: ignore[assignment]
+
+
+class _BareCardFace(CardFaceMixin):
+    """Instantiable from a face dict; used to sweep CardFaceMixin in isolation."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._scryfall_data = data  # type: ignore[assignment]
+
+
+class _BareRelatedCard(RelatedCardsObjectMixin):
+    """Instantiable from a part dict; used to sweep RelatedCardsObjectMixin in isolation."""
 
     def __init__(self, data: dict[str, Any]) -> None:
         self._scryfall_data = data  # type: ignore[assignment]
@@ -161,6 +176,22 @@ def _load_corpus(*fixture_names: str) -> dict[str, dict[str, Any]]:
     return {name.split("__", 1)[-1]: _load_json(f"{name}.json") for name in fixture_names}
 
 
+def _load_subitem_corpus(*fixture_names: str, key: str) -> dict[str, dict[str, Any]]:
+    """Extract sub-array items from card fixtures, keyed by fixture stem and item index.
+
+    Each item in payload[key] becomes a separate corpus entry, so every face or
+    related-card object can be swept independently as a first-class fixture row.
+    """
+    corpus: dict[str, dict[str, Any]] = {}
+    for name in fixture_names:
+        payload = _load_json(f"{name}.json")
+        items: list[dict[str, Any]] = payload.get(key) or []
+        stem = name.split("__", 1)[-1]
+        for idx, item in enumerate(items):
+            corpus[f"{stem}_{idx}"] = item
+    return corpus
+
+
 # Card object fixtures: 12 layout pins plus 11 accessor pins, so that between
 # them every optional card field lands on at least one fixture.
 CARD_CORPUS: dict[str, dict[str, Any]] = _load_corpus(
@@ -209,6 +240,37 @@ LIST_CORPUS: dict[str, dict[str, Any]] = _load_corpus(
 # Catalog envelope fixtures (object == "catalog")
 CATALOG_CORPUS: dict[str, dict[str, Any]] = _load_corpus("catalogs_creature_types")
 
+# Card face fixtures: one entry per face object extracted from multi-face card
+# captures. Together these 9 fixtures cover all 23 CardFaceMixin accessors.
+CARD_FACE_CORPUS: dict[str, dict[str, Any]] = _load_subitem_corpus(
+    "cards_by_id__adventure",
+    "cards_by_id__battle_dfc",
+    "cards_by_id__flip",
+    "cards_by_id__japanese_dfc",
+    "cards_by_id__modal_dfc",
+    "cards_by_id__planeswalker_transform",
+    "cards_by_id__reversible",
+    "cards_by_id__split",
+    "cards_by_id__transform",
+    key="card_faces",
+)
+
+# Related-card fixtures: one entry per all_parts item. All 6 RelatedCardsObjectMixin
+# accessors appear in every fixture, so a single fixture would suffice, but including
+# several gives richer parametrization.
+RELATED_CARD_CORPUS: dict[str, dict[str, Any]] = _load_subitem_corpus(
+    "cards_named__black_lotus",
+    "cards_by_id__adventure",
+    "cards_by_id__attraction",
+    "cards_by_id__etched",
+    "cards_by_id__meld",
+    "cards_by_id__modal_dfc",
+    "cards_by_id__planeswalker_transform",
+    "cards_by_id__reversible",
+    "cards_by_id__transform",
+    key="all_parts",
+)
+
 
 # ─── Hand-maintained artifacts (one line to extend each) ─────────────────────
 
@@ -237,13 +299,12 @@ CARD_ALIASES: dict[str, AliasPath] = {
     "preview_source": ("preview", "source"),
 }
 
-# Alias-less exceptions: each maps to the pytest node id of the test that owns
-# its coverage. The wrapped list accessors are covered by the gameplay-field
-# type sweep, which parametrizes over them; the computed predicates are covered
-# one test apiece.
+# Wrapped-list exceptions: each maps to the pytest node id of the test that owns
+# its coverage. card_faces and all_parts are swept by dedicated specs below;
+# the computed predicates are covered one test apiece.
 CARD_COVERED_ELSEWHERE: dict[str, str] = {
-    "all_parts": "tests/test_property_types.py::TestCardGameplayFields::test_gameplay_field_type",
-    "card_faces": "tests/test_property_types.py::TestCardGameplayFields::test_gameplay_field_type",
+    "all_parts": "tests/sweep/test_property_sweep.py::test_passthrough_sweep",
+    "card_faces": "tests/sweep/test_property_sweep.py::test_passthrough_sweep",
     "is_creature": "tests/test_convenience.py::TestCardConvenienceMethods::test_is_creature",
     "is_instant": "tests/test_convenience.py::TestCardConvenienceMethods::test_is_instant",
     "is_sorcery": "tests/test_convenience.py::TestCardConvenienceMethods::test_is_sorcery",
@@ -275,6 +336,18 @@ SWEEP_SPECS: tuple[SweepSpec, ...] = (
     SweepSpec(name="bulk_data", cls=BulkDataObject, build=BulkDataObject, corpus=BULK_DATA_CORPUS),
     SweepSpec(name="list", cls=_BareList, build=_BareList, corpus=LIST_CORPUS),
     SweepSpec(name="catalog", cls=_BareCatalog, build=_BareCatalog, corpus=CATALOG_CORPUS),
+    SweepSpec(
+        name="card_face",
+        cls=CardFaceMixin,
+        build=_BareCardFace,
+        corpus=CARD_FACE_CORPUS,
+    ),
+    SweepSpec(
+        name="related_card",
+        cls=RelatedCardsObjectMixin,
+        build=_BareRelatedCard,
+        corpus=RELATED_CARD_CORPUS,
+    ),
 )
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/sweep/test_property_sweep.py
+++ b/tests/sweep/test_property_sweep.py
@@ -181,11 +181,21 @@ def _load_subitem_corpus(*fixture_names: str, key: str) -> dict[str, dict[str, A
 
     Each item in payload[key] becomes a separate corpus entry, so every face or
     related-card object can be swept independently as a first-class fixture row.
+
+    Raises:
+        ValueError: A named fixture carries no items under `key`. Such a fixture
+            would contribute no rows and no signal, so it fails loudly instead.
     """
     corpus: dict[str, dict[str, Any]] = {}
     for name in fixture_names:
         payload = _load_json(f"{name}.json")
         items: list[dict[str, Any]] = payload.get(key) or []
+        if not items:
+            raise ValueError(
+                f"Sweep fixture '{name}' has no '{key}' items and so contributes nothing "
+                f"to this corpus. Drop it from the corpus list, or re-capture it from a "
+                f"card that carries {key}."
+            )
         stem = name.split("__", 1)[-1]
         for idx, item in enumerate(items):
             corpus[f"{stem}_{idx}"] = item
@@ -300,11 +310,12 @@ CARD_ALIASES: dict[str, AliasPath] = {
 }
 
 # Wrapped-list exceptions: each maps to the pytest node id of the test that owns
-# its coverage. card_faces and all_parts are swept by dedicated specs below;
-# the computed predicates are covered one test apiece.
+# its coverage. The card_face and related_card specs sweep the unwrapped items,
+# so the wrapping itself is owned by a test apiece at the foot of this module;
+# the computed predicates are covered one test apiece too.
 CARD_COVERED_ELSEWHERE: dict[str, str] = {
-    "all_parts": "tests/sweep/test_property_sweep.py::test_passthrough_sweep",
-    "card_faces": "tests/sweep/test_property_sweep.py::test_passthrough_sweep",
+    "all_parts": "tests/sweep/test_property_sweep.py::test_all_parts_wraps_every_raw_part",
+    "card_faces": "tests/sweep/test_property_sweep.py::test_card_faces_wraps_every_raw_face",
     "is_creature": "tests/test_convenience.py::TestCardConvenienceMethods::test_is_creature",
     "is_instant": "tests/test_convenience.py::TestCardConvenienceMethods::test_is_instant",
     "is_sorcery": "tests/test_convenience.py::TestCardConvenienceMethods::test_is_sorcery",
@@ -448,3 +459,34 @@ def test_wrapped_list_data_preserves_items() -> None:
     fixture = LIST_CORPUS["lea_red"]
     wrapped = _WrappedList(fixture)
     assert wrapped.to_list() == fixture["data"]
+
+
+# ─── Wrapped card sub-object accessors ────────────────────────────────────────
+
+# card_faces and all_parts wrap their raw items, so the passthrough sweep skips
+# them and the card_face/related_card specs sweep the unwrapped items instead.
+# That leaves the wrapping itself unasserted, which is what these two tests own.
+
+_WRAPPING_FIXTURE = CARD_CORPUS["transform"]
+
+
+def test_card_faces_wraps_every_raw_face() -> None:
+    """Card.card_faces builds one CardFaceMixin per raw face, in fixture order."""
+    faces = Object.from_dict(_WRAPPING_FIXTURE).card_faces
+    assert (
+        faces is not None
+    ), "fixture 'transform' must carry card_faces for this test to mean anything"
+
+    assert all(isinstance(face, CardFaceMixin) for face in faces)
+    assert [face.name for face in faces] == [raw["name"] for raw in _WRAPPING_FIXTURE["card_faces"]]
+
+
+def test_all_parts_wraps_every_raw_part() -> None:
+    """Card.all_parts builds one RelatedCardsObjectMixin per raw part, in fixture order."""
+    parts = Object.from_dict(_WRAPPING_FIXTURE).all_parts
+    assert (
+        parts is not None
+    ), "fixture 'transform' must carry all_parts for this test to mean anything"
+
+    assert all(isinstance(part, RelatedCardsObjectMixin) for part in parts)
+    assert [part.id for part in parts] == [raw["id"] for raw in _WRAPPING_FIXTURE["all_parts"]]

--- a/tests/sweep/test_sweep_engine_self.py
+++ b/tests/sweep/test_sweep_engine_self.py
@@ -8,7 +8,7 @@ the passthrough sweep and the exception sweep.
 """
 
 from importlib import import_module
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -18,7 +18,6 @@ from tests.sweep.test_property_sweep import (
     _SPECS_BY_NAME,
     SWEEP_SPECS,
     SweepSpec,
-    _alias_reachable,
     _resolve_alias,
     _run_passthrough_check,
 )
@@ -31,6 +30,18 @@ def _resolve_node_id(node_id: str) -> Any:
     for attribute_name in attribute_names:
         target = getattr(target, attribute_name)
     return target
+
+
+def _referenced_names(func: Any) -> frozenset[str]:
+    """Names a function's own body reads, as attributes, globals, or string literals.
+
+    Read off the code object rather than the source text, so a test that merely
+    carries an accessor's name in its own function name does not count as
+    referencing it.
+    """
+    code = func.__code__
+    literals = {const for const in code.co_consts if isinstance(const, str)}
+    return frozenset(set(code.co_names) | literals)
 
 
 _COVERAGE_REFERENCE_PARAMS = [
@@ -177,6 +188,25 @@ def test_covered_elsewhere_reference_resolves(spec_name: str, accessor: str, nod
     assert callable(owning_test), f"'{node_id}' resolves to {owning_test!r}, not a test function"
 
 
+@pytest.mark.parametrize("spec_name,accessor,node_id", _COVERAGE_REFERENCE_PARAMS)
+def test_covered_elsewhere_owner_reads_the_accessor(
+    spec_name: str, accessor: str, node_id: str
+) -> None:
+    """Each covered_elsewhere owner must actually read the accessor it claims.
+
+    Resolving to a callable is not coverage. Without this, an entry can name any
+    test at all — including one of the engine's own parametrized sweeps, which
+    reads accessors through getattr and so covers no accessor in particular.
+    """
+    owning_test = _resolve_node_id(node_id)
+
+    assert accessor in _referenced_names(owning_test), (
+        f"{spec_name} accessor '{accessor}' names owning test '{node_id}', "
+        f"whose body never reads '{accessor}' — point the entry at a test that "
+        f"asserts this accessor, or write one"
+    )
+
+
 # ─── Hard-fail completeness guard ─────────────────────────────────────────────
 
 _COMPLETENESS_PARAMS = [
@@ -185,38 +215,30 @@ _COMPLETENESS_PARAMS = [
     for accessor in sorted(spec.properties)
 ]
 
+# Read off the sweep's own parametrize lists rather than re-deriving which
+# accessors they reach, so an accessor that drops out of both sweeps cannot stay
+# green here through a second copy of the selection logic drifting out of step.
+_SWEPT_ACCESSORS: frozenset[tuple[str, str]] = frozenset(
+    cast("tuple[str, str]", (param.values[0], param.values[2]))
+    for param in _PASSTHROUGH_PARAMS + _EXCEPTION_PARAMS
+)
+
 
 @pytest.mark.parametrize("spec_name,accessor", _COMPLETENESS_PARAMS)
 def test_every_accessor_is_asserted(spec_name: str, accessor: str) -> None:
     """Every accessor must be value-asserted by passthrough, exception, or covered_elsewhere.
 
-    Fails when an accessor is present on the class but its key never appears in
-    any fixture AND it has no alias AND it has no covered_elsewhere entry. Deleting
-    a fixture or removing an assertion turns this test red.
+    Fails when an accessor is reached by neither sweep and has no covered_elsewhere
+    entry. Deleting the fixture that carries a field turns this test red, as does
+    dropping an alias for a renamed or nested field.
     """
     spec = _SPECS_BY_NAME[spec_name]
 
     if accessor in spec.covered_elsewhere:
         return
 
-    if accessor in spec.exceptions:
-        if accessor in spec.aliases:
-            alias = spec.aliases[accessor]
-            asserted = any(_alias_reachable(fixture, alias) for fixture in spec.corpus.values())
-            assert asserted, (
-                f"{spec_name} accessor '{accessor}' is aliased to {alias!r} "
-                "but that target appears in no fixture — "
-                "add a fixture that exposes it or declare covered_elsewhere"
-            )
-        else:
-            pytest.fail(
-                f"{spec_name} accessor '{accessor}' is an exception with no alias "
-                "and no covered_elsewhere entry"
-            )
-        return
-
-    asserted = any(accessor in fixture for fixture in spec.corpus.values())
-    assert asserted, (
-        f"{spec_name} accessor '{accessor}' appears in no fixture — "
-        "add a fixture that exposes this field or declare it covered_elsewhere"
+    assert (spec_name, accessor) in _SWEPT_ACCESSORS, (
+        f"{spec_name} accessor '{accessor}' is asserted by neither sweep — "
+        "add a fixture carrying its field, add an alias if the fixture key is "
+        "renamed or nested, or declare covered_elsewhere naming the owning test"
     )

--- a/tests/sweep/test_sweep_engine_self.py
+++ b/tests/sweep/test_sweep_engine_self.py
@@ -18,6 +18,7 @@ from tests.sweep.test_property_sweep import (
     _SPECS_BY_NAME,
     SWEEP_SPECS,
     SweepSpec,
+    _alias_reachable,
     _resolve_alias,
     _run_passthrough_check,
 )
@@ -174,3 +175,48 @@ def test_covered_elsewhere_reference_resolves(spec_name: str, accessor: str, nod
         )
 
     assert callable(owning_test), f"'{node_id}' resolves to {owning_test!r}, not a test function"
+
+
+# ─── Hard-fail completeness guard ─────────────────────────────────────────────
+
+_COMPLETENESS_PARAMS = [
+    pytest.param(spec.name, accessor, id=f"{spec.name}-{accessor}")
+    for spec in SWEEP_SPECS
+    for accessor in sorted(spec.properties)
+]
+
+
+@pytest.mark.parametrize("spec_name,accessor", _COMPLETENESS_PARAMS)
+def test_every_accessor_is_asserted(spec_name: str, accessor: str) -> None:
+    """Every accessor must be value-asserted by passthrough, exception, or covered_elsewhere.
+
+    Fails when an accessor is present on the class but its key never appears in
+    any fixture AND it has no alias AND it has no covered_elsewhere entry. Deleting
+    a fixture or removing an assertion turns this test red.
+    """
+    spec = _SPECS_BY_NAME[spec_name]
+
+    if accessor in spec.covered_elsewhere:
+        return
+
+    if accessor in spec.exceptions:
+        if accessor in spec.aliases:
+            alias = spec.aliases[accessor]
+            asserted = any(_alias_reachable(fixture, alias) for fixture in spec.corpus.values())
+            assert asserted, (
+                f"{spec_name} accessor '{accessor}' is aliased to {alias!r} "
+                "but that target appears in no fixture — "
+                "add a fixture that exposes it or declare covered_elsewhere"
+            )
+        else:
+            pytest.fail(
+                f"{spec_name} accessor '{accessor}' is an exception with no alias "
+                "and no covered_elsewhere entry"
+            )
+        return
+
+    asserted = any(accessor in fixture for fixture in spec.corpus.values())
+    assert asserted, (
+        f"{spec_name} accessor '{accessor}' appears in no fixture — "
+        "add a fixture that exposes this field or declare it covered_elsewhere"
+    )


### PR DESCRIPTION
Closes #237

Opened by Sandcastle. 1 commit(s) on `sandcastle/issue-237`.